### PR TITLE
ci: add unit test workflow

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,40 @@
+name: Python Unit Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Test against all Python versions supported in pyproject.toml
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv
+          source .venv/bin/activate
+          # Install dependencies as recommended in CONTRIBUTING.md
+          uv sync --extra test --extra eval --extra a2a
+
+      - name: Run unit tests with pytest
+        run: |
+          source .venv/bin/activate
+          # Run all tests in the tests/unittests directory
+          pytest tests/unittests


### PR DESCRIPTION
Adds a GitHub Actions workflow to run unit tests.

This workflow runs pytest on all supported Python versions (3.9-3.13)
as specified in pyproject.toml. The job is triggered on
every push and pull request to the main branch.

Closes #8