### PR TITLE
feat: Add S3 support for artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [ # List of https://pypi.org/classifiers/
 ]
 dependencies = [
   # go/keep-sorted start
+  "aioboto3>=15.5.0", # For S3 Artifact Storage
   "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,12 @@ classifiers = [ # List of https://pypi.org/classifiers/
   "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-  # go/keep-sorted start
   "aioboto3>=15.5.0", # For S3 Artifact Storage
   "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
-  "redis>=5.0.0, <6.0.0", # Redis for session storage
-  # go/keep-sorted end
   "orjson>=3.11.3",
+  "redis>=5.0.0, <6.0.0", # Redis for session storage
 ]
 dynamic = ["version"]
 

--- a/src/google/adk_community/__init__.py
+++ b/src/google/adk_community/__init__.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import artifacts
 from . import memory
 from . import sessions
 from . import version
+
 __version__ = version.__version__

--- a/src/google/adk_community/artifacts/__init__.py
+++ b/src/google/adk_community/artifacts/__init__.py
@@ -1,0 +1,5 @@
+"""Community session services for ADK."""
+
+from .s3_artifact_service import S3ArtifactService
+
+__all__ = ["S3ArtifactService"]

--- a/src/google/adk_community/artifacts/s3_artifact_service.py
+++ b/src/google/adk_community/artifacts/s3_artifact_service.py
@@ -1,0 +1,373 @@
+"""An artifact service implementation using Amazon S3 or other S3-compatible services.
+
+The blob/key name format depends on whether the filename has a user namespace:
+  - For files with user namespace (starting with "user:"):
+    {app_name}/{user_id}/user/{filename}/{version}
+  - For regular session-scoped files:
+    {app_name}/{user_id}/{session_id}/{filename}/{version}
+
+This service supports storing and retrieving artifacts with inline data or text.
+Artifacts can also have optional custom metadata, which is serialized as JSON
+when stored in S3.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from google.adk.artifacts.base_artifact_service import ArtifactVersion
+from google.adk.artifacts.base_artifact_service import BaseArtifactService
+from google.genai import types
+from pydantic import BaseModel
+from typing_extensions import override
+
+logger = logging.getLogger("google_adk." + __name__)
+
+
+class S3ArtifactService(BaseArtifactService, BaseModel):
+  """An artifact service implementation using Amazon S3 or other S3-compatible services.
+
+  Attributes:
+      bucket_name: The name of the S3 bucket to use for storing and retrieving artifacts.
+      aws_configs: A dictionary of AWS configuration options to pass to the boto3 client.
+      save_artifact_max_retries: The maximum number of retries to attempt when saving an artifact with version conflicts.
+          If set to -1, the service will retry indefinitely.
+  """
+
+  bucket_name: str
+  aws_configs: dict[str, Any] = {}
+  save_artifact_max_retries: int = -1
+  _s3_client: Any = None
+
+  async def _client(self):
+    """Creates or returns the aioboto3 S3 client."""
+    import aioboto3
+
+    if self._s3_client is None:
+      self._s3_client = (
+          await aioboto3.Session()
+          .client(service_name="s3", **self.aws_configs)
+          .__aenter__()
+      )
+    return self._s3_client
+
+  async def close(self):
+    """Closes the underlying S3 client session."""
+    if self._s3_client:
+      await self._s3_client.__aexit__(None, None, None)
+      self._s3_client = None
+
+  def _flatten_metadata(self, metadata: dict[str, Any]) -> dict[str, str]:
+    return {k: json.dumps(v) for k, v in (metadata or {}).items()}
+
+  def _unflatten_metadata(self, metadata: dict[str, str]) -> dict[str, Any]:
+    results = {}
+    for k, v in (metadata or {}).items():
+      try:
+        results[k] = json.loads(v)
+      except json.JSONDecodeError:
+        logger.warning(
+            f"Failed to decode metadata value for key {k}. Using raw string."
+        )
+        results[k] = v
+    return results
+
+  def _file_has_user_namespace(self, filename: str) -> bool:
+    return filename.startswith("user:")
+
+  def _get_blob_prefix(
+      self, app_name: str, user_id: str, session_id: str | None, filename: str
+  ) -> str:
+    if self._file_has_user_namespace(filename):
+      return f"{app_name}/{user_id}/user/{filename}"
+    if session_id:
+      return f"{app_name}/{user_id}/{session_id}/{filename}"
+    raise ValueError("session_id is required for session-scoped artifacts.")
+
+  def _get_blob_name(
+      self,
+      app_name: str,
+      user_id: str,
+      session_id: str | None,
+      filename: str,
+      version: int,
+  ) -> str:
+    return (
+        f"{self._get_blob_prefix(app_name, user_id, session_id, filename)}/{version}"
+    )
+
+  @override
+  async def save_artifact(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      filename: str,
+      artifact: types.Part,
+      session_id: str | None = None,
+      custom_metadata: dict[str, Any] | None = None,
+  ) -> int:
+    """Saves an artifact to S3 with atomic versioning using If-None-Match."""
+    from botocore.exceptions import ClientError
+
+    s3 = await self._client()
+
+    if self.save_artifact_max_retries < 0:
+      retry_iter = iter(int, 1)
+    else:
+      retry_iter = range(self.save_artifact_max_retries + 1)
+    for _ in retry_iter:
+      versions = await self.list_versions(
+          app_name=app_name,
+          user_id=user_id,
+          filename=filename,
+          session_id=session_id,
+      )
+      version = 0 if not versions else max(versions) + 1
+      key = self._get_blob_name(
+          app_name, user_id, session_id, filename, version
+      )
+      if artifact.inline_data:
+        body = artifact.inline_data.data
+        mime_type = artifact.inline_data.mime_type
+      elif artifact.text:
+        body = artifact.text
+        mime_type = "text/plain"
+      elif artifact.file_data:
+        raise NotImplementedError(
+            "Saving artifact with file_data is not supported yet in"
+            " S3ArtifactService."
+        )
+      else:
+        raise ValueError("Artifact must have either inline_data or text.")
+
+      try:
+        await s3.put_object(
+            Bucket=self.bucket_name,
+            Key=key,
+            Body=body,
+            ContentType=mime_type,
+            Metadata=self._flatten_metadata(custom_metadata),
+            IfNoneMatch="*",
+        )
+        return version
+      except ClientError as e:
+        if e.response["Error"]["Code"] in (
+            "PreconditionFailed",
+            "ObjectAlreadyExists",
+        ):
+          continue
+        raise e
+    raise RuntimeError(
+        "Failed to save artifact due to version conflicts after retries"
+    )
+
+  @override
+  async def load_artifact(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      filename: str,
+      session_id: str | None = None,
+      version: int | None = None,
+  ) -> types.Part | None:
+    """Loads a specific version of an artifact from S3.
+
+    If version is not provided, the latest version is loaded.
+
+    Returns:
+        A types.Part instance (always with inline_data), or None if the artifact does not exist.
+    """
+    from botocore.exceptions import ClientError
+
+    s3 = await self._client()
+    if version is None:
+      versions = await self.list_versions(
+          app_name=app_name,
+          user_id=user_id,
+          filename=filename,
+          session_id=session_id,
+      )
+      if not versions:
+        return None
+      version = max(versions)
+
+    key = self._get_blob_name(app_name, user_id, session_id, filename, version)
+    try:
+      response = await s3.get_object(Bucket=self.bucket_name, Key=key)
+      async with response["Body"] as stream:
+        data = await stream.read()
+      mime_type = response["ContentType"]
+    except ClientError as e:
+      if e.response["Error"]["Code"] in ("NoSuchKey", "404"):
+        return None
+      raise
+    return types.Part.from_bytes(data=data, mime_type=mime_type)
+
+  @override
+  async def list_artifact_keys(
+      self, *, app_name: str, user_id: str, session_id: str | None = None
+  ) -> list[str]:
+    """Lists all artifact keys for a user, optionally filtered by session."""
+    s3 = await self._client()
+    keys = set()
+    prefixes = [
+        f"{app_name}/{user_id}/{session_id}/" if session_id else None,
+        f"{app_name}/{user_id}/user/",
+    ]
+
+    for prefix in filter(None, prefixes):
+      paginator = s3.get_paginator("list_objects_v2")
+      async for page in paginator.paginate(
+          Bucket=self.bucket_name, Prefix=prefix
+      ):
+        for obj in page.get("Contents", []):
+          relative = obj["Key"][len(prefix) :]
+          filename = "/".join(relative.split("/")[:-1])
+          keys.add(filename)
+    return sorted(keys)
+
+  @override
+  async def delete_artifact(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      filename: str,
+      session_id: str | None = None,
+  ) -> None:
+    """Deletes all versions of a specified artifact efficiently using batch delete."""
+    s3 = await self._client()
+    versions = await self.list_versions(
+        app_name=app_name,
+        user_id=user_id,
+        filename=filename,
+        session_id=session_id,
+    )
+    if not versions:
+      return
+
+    keys_to_delete = [
+        {"Key": self._get_blob_name(app_name, user_id, session_id, filename, v)}
+        for v in versions
+    ]
+    for i in range(0, len(keys_to_delete), 1000):
+      batch = keys_to_delete[i : i + 1000]
+      await s3.delete_objects(
+          Bucket=self.bucket_name, Delete={"Objects": batch}
+      )
+
+  @override
+  async def list_versions(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      filename: str,
+      session_id: str | None = None,
+  ) -> list[int]:
+    """Lists all available versions of a specified artifact."""
+    s3 = await self._client()
+    prefix = (
+        self._get_blob_prefix(app_name, user_id, session_id, filename) + "/"
+    )
+    versions = []
+    paginator = s3.get_paginator("list_objects_v2")
+    async for page in paginator.paginate(
+        Bucket=self.bucket_name, Prefix=prefix
+    ):
+      for obj in page.get("Contents", []):
+        try:
+          versions.append(int(obj["Key"].split("/")[-1]))
+        except ValueError:
+          continue
+    return sorted(versions)
+
+  @override
+  async def list_artifact_versions(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      filename: str,
+      session_id: str | None = None,
+  ) -> list[ArtifactVersion]:
+    """Lists all artifact versions with their metadata."""
+    s3 = await self._client()
+    prefix = (
+        self._get_blob_prefix(app_name, user_id, session_id, filename) + "/"
+    )
+    results: list[ArtifactVersion] = []
+
+    paginator = s3.get_paginator("list_objects_v2")
+    async for page in paginator.paginate(
+        Bucket=self.bucket_name, Prefix=prefix
+    ):
+      for obj in page.get("Contents", []):
+        try:
+          version = int(obj["Key"].split("/")[-1])
+        except ValueError:
+          continue
+
+        head = await s3.head_object(Bucket=self.bucket_name, Key=obj["Key"])
+        mime_type = head["ContentType"]
+        metadata = head.get("Metadata", {})
+
+        canonical_uri = f"s3://{self.bucket_name}/{obj['Key']}"
+
+        results.append(
+            ArtifactVersion(
+                version=version,
+                canonical_uri=canonical_uri,
+                custom_metadata=self._unflatten_metadata(metadata),
+                create_time=obj["LastModified"].timestamp(),
+                mime_type=mime_type,
+            )
+        )
+
+    return sorted(results, key=lambda a: a.version)
+
+  @override
+  async def get_artifact_version(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      filename: str,
+      session_id: str | None = None,
+      version: int | None = None,
+  ) -> ArtifactVersion | None:
+    """Retrieves a specific artifact version, or the latest if version is None."""
+    s3 = await self._client()
+    if version is None:
+      all_versions = await self.list_versions(
+          app_name=app_name,
+          user_id=user_id,
+          filename=filename,
+          session_id=session_id,
+      )
+      if not all_versions:
+        return None
+      version = max(all_versions)
+
+    key = self._get_blob_name(app_name, user_id, session_id, filename, version)
+
+    from botocore.exceptions import ClientError
+
+    try:
+      head = await s3.head_object(Bucket=self.bucket_name, Key=key)
+    except ClientError as e:
+      if e.response["Error"]["Code"] in ("NoSuchKey", "404"):
+        return None
+      raise
+
+    return ArtifactVersion(
+        version=version,
+        canonical_uri=f"s3://{self.bucket_name}/{key}",
+        custom_metadata=self._unflatten_metadata(head.get("Metadata", {})),
+        create_time=head["LastModified"].timestamp(),
+        mime_type=head["ContentType"],
+    )

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -1,0 +1,635 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+"""Tests for the artifact service."""
+
+import asyncio
+from datetime import datetime
+import enum
+from pathlib import Path
+import random
+import sys
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from google.adk.artifacts.base_artifact_service import ArtifactVersion
+from google.genai import types
+import pytest
+
+from google.adk_community.artifacts.s3_artifact_service import S3ArtifactService
+
+Enum = enum.Enum
+
+# Define a fixed datetime object to be returned by datetime.now()
+FIXED_DATETIME = datetime(2025, 1, 1, 12, 0, 0)
+
+
+class ArtifactServiceType(Enum):
+  S3 = "S3"
+
+
+class MockBody:
+
+  def __init__(self, data: bytes):
+    self._data = data
+
+  async def read(self) -> bytes:
+    return self._data
+
+  async def __aenter__(self):
+    return self
+
+  async def __aexit__(self, exc_type, exc, tb):
+    pass
+
+
+class MockAsyncS3Object:
+
+  def __init__(self, key):
+    self.key = key
+    self.data = None
+    self.content_type = None
+    self.metadata = {}
+    self.last_modified = FIXED_DATETIME
+
+  async def put(self, Body, ContentType=None, Metadata=None):
+    self.data = Body if isinstance(Body, bytes) else Body.encode("utf-8")
+    self.content_type = ContentType
+    self.metadata = Metadata or {}
+
+  async def get(self):
+    if self.data is None:
+      raise ClientError(
+          {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
+          operation_name="GetObject",
+      )
+    return {
+        "Body": MockBody(self.data),
+        "ContentType": self.content_type,
+        "Metadata": self.metadata,
+        "LastModified": self.last_modified,
+    }
+
+
+class MockAsyncS3Bucket:
+
+  def __init__(self, name):
+    self.name = name
+    self.objects = {}
+
+  def object(self, key):
+    if key not in self.objects:
+      self.objects[key] = MockAsyncS3Object(key)
+    return self.objects[key]
+
+  async def listed_keys(self, prefix=None):
+    return [
+        k
+        for k, obj in self.objects.items()
+        if obj.data is not None and (prefix is None or k.startswith(prefix))
+    ]
+
+
+class MockAsyncS3Client:
+
+  def __init__(self):
+    self.buckets = {}
+
+  def get_bucket(self, bucket_name):
+    if bucket_name not in self.buckets:
+      self.buckets[bucket_name] = MockAsyncS3Bucket(bucket_name)
+    return self.buckets[bucket_name]
+
+  async def put_object(
+      self, Bucket, Key, Body, ContentType=None, Metadata=None, IfNoneMatch=None
+  ):
+    await asyncio.sleep(random.uniform(0, 0.05))
+    bucket = self.get_bucket(Bucket)
+    obj_exists = Key in bucket.objects and bucket.objects[Key].data is not None
+
+    if IfNoneMatch == "*" and obj_exists:
+      raise ClientError(
+          {"Error": {"Code": "PreconditionFailed", "Message": "Object exists"}},
+          operation_name="PutObject",
+      )
+
+    await bucket.object(Key).put(
+        Body=Body, ContentType=ContentType, Metadata=Metadata
+    )
+
+  async def get_object(self, Bucket, Key):
+    bucket = self.get_bucket(Bucket)
+    obj = bucket.object(Key)
+    return await obj.get()
+
+  async def delete_object(self, Bucket, Key):
+    bucket = self.get_bucket(Bucket)
+    bucket.objects.pop(Key, None)
+
+  async def delete_objects(self, Bucket, Delete):
+    bucket = self.get_bucket(Bucket)
+    for item in Delete.get("Objects", []):
+      key = item.get("Key")
+      if key in bucket.objects:
+        bucket.objects.pop(key)
+
+  async def list_objects_v2(self, Bucket, Prefix=None):
+    bucket = self.get_bucket(Bucket)
+    keys = await bucket.listed_keys(Prefix)
+    return {
+        "KeyCount": len(keys),
+        "Contents": [
+            {"Key": k, "LastModified": bucket.objects[k].last_modified}
+            for k in keys
+        ],
+    }
+
+  async def head_object(self, Bucket, Key):
+    obj = await self.get_object(Bucket, Key)
+    return {
+        "ContentType": obj["ContentType"],
+        "Metadata": obj.get("Metadata", {}),
+        "LastModified": obj.get("LastModified"),
+    }
+
+  def get_paginator(self, operation_name):
+    if operation_name != "list_objects_v2":
+      raise NotImplementedError(
+          f"Paginator for {operation_name} not implemented"
+      )
+
+    class MockAsyncPaginator:
+
+      def __init__(self, client, Bucket, Prefix=None):
+        self.client = client
+        self.Bucket = Bucket
+        self.Prefix = Prefix
+
+      async def __aiter__(self):
+        response = await self.client.list_objects_v2(
+            Bucket=self.Bucket, Prefix=self.Prefix
+        )
+        contents = response.get("Contents", [])
+        page_size = 2
+        for i in range(0, len(contents), page_size):
+          yield {
+              "KeyCount": len(contents[i : i + page_size]),
+              "Contents": contents[i : i + page_size],
+          }
+
+    class MockPaginator:
+
+      def paginate(inner_self, Bucket, Prefix=None):
+        return MockAsyncPaginator(self, Bucket, Prefix)
+
+    return MockPaginator()
+
+
+def mock_s3_artifact_service(monkeypatch):
+  mock_s3_client = MockAsyncS3Client()
+
+  class MockAioboto3:
+
+    class Session:
+
+      def client(self, *args, **kwargs):
+        class MockClientCtx:
+
+          async def __aenter__(self_inner):
+            return mock_s3_client
+
+          async def __aexit__(self_inner, exc_type, exc, tb):
+            pass
+
+        return MockClientCtx()
+
+  monkeypatch.setitem(sys.modules, "aioboto3", MockAioboto3)
+  artifact_service = S3ArtifactService(bucket_name="test_bucket")
+  return artifact_service
+
+
+@pytest.fixture
+def artifact_service_factory(tmp_path: Path, monkeypatch):
+  """Provides an artifact service constructor bound to the test tmp path."""
+
+  def factory(
+      service_type: ArtifactServiceType = ArtifactServiceType.S3,
+  ):
+    if service_type == ArtifactServiceType.S3:
+      return mock_s3_artifact_service(monkeypatch)
+
+  return factory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_load_empty(service_type, artifact_service_factory):
+  """Tests loading an artifact when none exists."""
+  artifact_service = artifact_service_factory(service_type)
+  assert not await artifact_service.load_artifact(
+      app_name="test_app",
+      user_id="test_user",
+      session_id="session_id",
+      filename="filename",
+  )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_save_load_delete(service_type, artifact_service_factory):
+  """Tests saving, loading, and deleting an artifact."""
+  artifact_service = artifact_service_factory(service_type)
+  artifact = types.Part.from_bytes(data=b"test_data", mime_type="text/plain")
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "123"
+  filename = "file456"
+
+  await artifact_service.save_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+      artifact=artifact,
+  )
+  assert (
+      await artifact_service.load_artifact(
+          app_name=app_name,
+          user_id=user_id,
+          session_id=session_id,
+          filename=filename,
+      )
+      == artifact
+  )
+
+  # Attempt to load a version that doesn't exist
+  assert not await artifact_service.load_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+      version=3,
+  )
+
+  await artifact_service.delete_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+  )
+  assert not await artifact_service.load_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+  )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_list_keys(service_type, artifact_service_factory):
+  """Tests listing keys in the artifact service."""
+  artifact_service = artifact_service_factory(service_type)
+  artifact = types.Part.from_bytes(data=b"test_data", mime_type="text/plain")
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "123"
+  filename = "filename"
+  filenames = [filename + str(i) for i in range(5)]
+
+  for f in filenames:
+    await artifact_service.save_artifact(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        filename=f,
+        artifact=artifact,
+    )
+
+  assert (
+      await artifact_service.list_artifact_keys(
+          app_name=app_name, user_id=user_id, session_id=session_id
+      )
+      == filenames
+  )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_list_versions(service_type, artifact_service_factory):
+  """Tests listing versions of an artifact."""
+  artifact_service = artifact_service_factory(service_type)
+
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "123"
+  filename = "with/slash/filename"
+  versions = [
+      types.Part.from_bytes(
+          data=i.to_bytes(2, byteorder="big"), mime_type="text/plain"
+      )
+      for i in range(3)
+  ]
+  versions.append(types.Part.from_text(text="hello"))
+
+  for i in range(4):
+    await artifact_service.save_artifact(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        filename=filename,
+        artifact=versions[i],
+    )
+
+  response_versions = await artifact_service.list_versions(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+  )
+
+  assert response_versions == list(range(4))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_list_keys_preserves_user_prefix(
+    service_type, artifact_service_factory
+):
+  """Tests that list_artifact_keys preserves 'user:' prefix in returned names."""
+  artifact_service = artifact_service_factory(service_type)
+  artifact = types.Part.from_bytes(data=b"test_data", mime_type="text/plain")
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "123"
+
+  # Save artifacts with "user:" prefix (cross-session artifacts)
+  await artifact_service.save_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename="user:document.pdf",
+      artifact=artifact,
+  )
+
+  await artifact_service.save_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename="user:image.png",
+      artifact=artifact,
+  )
+
+  # Save session-scoped artifact without prefix
+  await artifact_service.save_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename="session_file.txt",
+      artifact=artifact,
+  )
+
+  # List artifacts should return names with "user:" prefix for user-scoped artifacts
+  artifact_keys = await artifact_service.list_artifact_keys(
+      app_name=app_name, user_id=user_id, session_id=session_id
+  )
+
+  # Should contain prefixed names and session file
+  expected_keys = ["user:document.pdf", "user:image.png", "session_file.txt"]
+  assert sorted(artifact_keys) == sorted(expected_keys)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_list_artifact_versions_and_get_artifact_version(
+    service_type, artifact_service_factory
+):
+  """Tests listing artifact versions and getting a specific version."""
+  artifact_service = artifact_service_factory(service_type)
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "123"
+  filename = "filename"
+  versions = [
+      types.Part.from_bytes(
+          data=i.to_bytes(2, byteorder="big"), mime_type="text/plain"
+      )
+      for i in range(4)
+  ]
+
+  with patch(
+      "google.adk.artifacts.base_artifact_service.datetime"
+  ) as mock_datetime:
+    mock_datetime.now.return_value = FIXED_DATETIME
+
+    for i in range(4):
+      custom_metadata = {"key": "value" + str(i)}
+      await artifact_service.save_artifact(
+          app_name=app_name,
+          user_id=user_id,
+          session_id=session_id,
+          filename=filename,
+          artifact=versions[i],
+          custom_metadata=custom_metadata,
+      )
+
+    artifact_versions = await artifact_service.list_artifact_versions(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        filename=filename,
+    )
+
+    expected_artifact_versions = []
+    for i in range(4):
+      metadata = {"key": "value" + str(i)}
+      if service_type == ArtifactServiceType.S3:
+        uri = (
+            f"s3://test_bucket/{app_name}/{user_id}/{session_id}/{filename}/{i}"
+        )
+      else:
+        uri = f"memory://apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{filename}/versions/{i}"
+      expected_artifact_versions.append(
+          ArtifactVersion(
+              version=i,
+              canonical_uri=uri,
+              custom_metadata=metadata,
+              mime_type="text/plain",
+              create_time=FIXED_DATETIME.timestamp(),
+          )
+      )
+    assert artifact_versions == expected_artifact_versions
+
+    # Get latest artifact version when version is not specified
+    assert (
+        await artifact_service.get_artifact_version(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+            filename=filename,
+        )
+        == expected_artifact_versions[-1]
+    )
+
+    # Get artifact version by version number
+    assert (
+        await artifact_service.get_artifact_version(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+            filename=filename,
+            version=2,
+        )
+        == expected_artifact_versions[2]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_list_artifact_versions_with_user_prefix(
+    service_type, artifact_service_factory
+):
+  """Tests listing artifact versions with user prefix."""
+  artifact_service = artifact_service_factory(service_type)
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "123"
+  user_scoped_filename = "user:document.pdf"
+  versions = [
+      types.Part.from_bytes(
+          data=i.to_bytes(2, byteorder="big"), mime_type="text/plain"
+      )
+      for i in range(4)
+  ]
+
+  with patch(
+      "google.adk.artifacts.base_artifact_service.datetime"
+  ) as mock_datetime:
+    mock_datetime.now.return_value = FIXED_DATETIME
+
+    for i in range(4):
+      custom_metadata = {"key": "value" + str(i)}
+      # Save artifacts with "user:" prefix (cross-session artifacts)
+      await artifact_service.save_artifact(
+          app_name=app_name,
+          user_id=user_id,
+          session_id=session_id,
+          filename=user_scoped_filename,
+          artifact=versions[i],
+          custom_metadata=custom_metadata,
+      )
+
+    artifact_versions = await artifact_service.list_artifact_versions(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        filename=user_scoped_filename,
+    )
+
+    expected_artifact_versions = []
+    for i in range(4):
+      metadata = {"key": "value" + str(i)}
+      if service_type == ArtifactServiceType.S3:
+        uri = f"s3://test_bucket/{app_name}/{user_id}/user/{user_scoped_filename}/{i}"
+      else:
+        uri = f"memory://apps/{app_name}/users/{user_id}/artifacts/{user_scoped_filename}/versions/{i}"
+      expected_artifact_versions.append(
+          ArtifactVersion(
+              version=i,
+              canonical_uri=uri,
+              custom_metadata=metadata,
+              mime_type="text/plain",
+              create_time=FIXED_DATETIME.timestamp(),
+          )
+      )
+    assert artifact_versions == expected_artifact_versions
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_get_artifact_version_artifact_does_not_exist(
+    service_type, artifact_service_factory
+):
+  """Tests getting an artifact version when artifact does not exist."""
+  artifact_service = artifact_service_factory(service_type)
+  assert not await artifact_service.get_artifact_version(
+      app_name="test_app",
+      user_id="test_user",
+      session_id="session_id",
+      filename="filename",
+  )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.S3,
+    ],
+)
+async def test_get_artifact_version_out_of_index(
+    service_type, artifact_service_factory
+):
+  """Tests loading an artifact with an out-of-index version."""
+  artifact_service = artifact_service_factory(service_type)
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "123"
+  filename = "filename"
+  artifact = types.Part.from_bytes(data=b"test_data", mime_type="text/plain")
+
+  await artifact_service.save_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+      artifact=artifact,
+  )
+
+  # Attempt to get a version that doesn't exist
+  assert not await artifact_service.get_artifact_version(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+      version=3,
+  )


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: google/adk-python#555
- Related:
  - google/adk-python#556
  - google/adk-python#3563

### Description
Introduce `S3ArtifactService` to provide an self-hosted Artifact storage solution

### Solution
- Supports asynchronous upload and download of S3 artifacts
- Includes unit tests covering core functionality
- Depends on `aioboto3`

### Testing Plan
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.
