### PR TITLE
Add MongoDB session service integration for ADK community

### DIFF
--- a/contributing/samples/mongodb_service/README.md
+++ b/contributing/samples/mongodb_service/README.md
@@ -127,7 +127,7 @@ What is the status of my university invoice? Also, calculate the tax for a servi
 
 ## Configuration options (`MongoSessionService`)
 
-- `database_name` (str, optional): Mongo database to store session data (defaults to `adk_sessions_db`)
+- `database_name` (str, default `adk_sessions_db`): Mongo database to store session data.
 - `connection_string` (str, optional): Mongo URI (mutually exclusive with `client`)
 - `client` (AsyncMongoClient, optional): Provide your own client/connection pool
 - `session_collection` (str, default `sessions`): Collection for session docs

--- a/contributing/samples/mongodb_service/README.md
+++ b/contributing/samples/mongodb_service/README.md
@@ -16,7 +16,7 @@ community `MongoSessionService`.
 ### 1. Install dependencies
 
 ```bash
-pip install google-adk google-adk-community
+pip install google-adk google-adk-community python-dotenv
 ```
 
 ### 2. Configure environment variables
@@ -31,9 +31,7 @@ GOOGLE_API_KEY=your-google-api-key
 MONGODB_URI=mongodb+srv://<user>:<password>@<cluster-url>/
 ```
 
-**Note:** Keep your Mongo credentials out of source control. The sample reads
-the URI directly in `main.py`; you can swap in `os.environ["MONGODB_URI"]` to
-load it from the environment.
+**Note:** Keep your Mongo credentials out of source control. The sample loads the connection string from the `MONGODB_URI` environment variable, which is loaded from the `.env` file at runtime.
 
 ### 3. Pick a database name
 
@@ -59,6 +57,7 @@ python main.py
 ```python
 import os
 from google.adk.runners import Runner
+from google.genai import types
 from google.adk_community.sessions import MongoSessionService
 
 session_service = MongoSessionService(
@@ -70,6 +69,8 @@ await session_service.create_session(
 )
 
 runner = Runner(app_name="my_app", agent=root_agent, session_service=session_service)
+query = "Hello, can you help me with my account?"
+content = types.Content(role="user", parts=[types.Part(text=query)])
 
 async for event in runner.run_async(
     user_id="user1",

--- a/contributing/samples/mongodb_service/README.md
+++ b/contributing/samples/mongodb_service/README.md
@@ -62,7 +62,7 @@ from google.adk.runners import Runner
 from google.adk_community.sessions import MongoSessionService
 
 session_service = MongoSessionService(
-    connection_string=os.environ["MONGODB_URI"]
+    connection_string=os.environ.get("MONGODB_URI")
 )
 
 await session_service.create_session(
@@ -126,13 +126,12 @@ What is the status of my university invoice? Also, calculate the tax for a servi
 
 ## Configuration options (`MongoSessionService`)
 
-- `database_name` (str, required): Mongo database to store session data
+- `database_name` (str, optional): Mongo database to store session data (defaults to `adk_sessions_db`)
 - `connection_string` (str, optional): Mongo URI (mutually exclusive with `client`)
 - `client` (AsyncMongoClient, optional): Provide your own client/connection pool
 - `session_collection` (str, default `sessions`): Collection for session docs
 - `state_collection` (str, default `session_state`): Collection for shared state
-- `default_app_name` (str, optional): Fallback app name when not provided per call
-- `mongo_appname` (str, default `adk-cosmos-session-service`): App name tag for Mongo driver telemetry
+- `default_app_name` (str, optional): Fallback app name when not provided per call (defaults to `adk-cosmos-session-service`)
 
 ## Tips
 

--- a/contributing/samples/mongodb_service/README.md
+++ b/contributing/samples/mongodb_service/README.md
@@ -132,7 +132,7 @@ What is the status of my university invoice? Also, calculate the tax for a servi
 - `client` (AsyncMongoClient, optional): Provide your own client/connection pool
 - `session_collection` (str, default `sessions`): Collection for session docs
 - `state_collection` (str, default `session_state`): Collection for shared state
-- `default_app_name` (str, optional): Fallback app name when not provided per call (defaults to `adk-cosmos-session-service`)
+- `default_app_name` (str, optional): Fallback app name when not provided per call (defaults to `adk-mongo-session-service`)
 
 ## Tips
 

--- a/contributing/samples/mongodb_service/README.md
+++ b/contributing/samples/mongodb_service/README.md
@@ -1,0 +1,142 @@
+# MongoDB Session Service Sample
+
+This sample shows how to persist ADK sessions and state in MongoDB using the
+community `MongoSessionService`.
+
+## Prerequisites
+
+- Python 3.9+ (Python 3.11+ recommended)
+- A running MongoDB instance (local or Atlas) and a connection string with
+  create/read/write permissions
+- ADK and ADK Community installed
+- Google API key for the sample agent (Gemini), set as `GOOGLE_API_KEY`
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+pip install google-adk google-adk-community
+```
+
+### 2. Configure environment variables
+
+Create a `.env` in this directory:
+
+```bash
+# Required: Google API key for the agent
+GOOGLE_API_KEY=your-google-api-key
+
+# Recommended: Mongo connection string (Atlas or local)
+MONGODB_URI=mongodb+srv://<user>:<password>@<cluster-url>/
+```
+
+**Note:** Keep your Mongo credentials out of source control. The sample reads
+the URI directly in `main.py`; you can swap in `os.environ["MONGODB_URI"]` to
+load it from the environment.
+
+### 3. Pick a database name
+
+By default the sample uses `adk_sessions_db`. Collections are created
+automatically if they do not exist.
+
+## Usage
+
+### Option 1: Run the included sample
+
+```bash
+python main.py
+```
+
+`main.py`:
+- Creates a `MongoSessionService` with a connection string
+- Creates a session for the demo user
+- Runs the `financial_advisor_agent` with `Runner.run_async`
+- Prints the agent's final response
+
+### Option 2: Use `MongoSessionService` with your own runner
+
+```python
+import os
+from google.adk.runners import Runner
+from google.adk_community.sessions import MongoSessionService
+
+session_service = MongoSessionService(
+    connection_string=os.environ["MONGODB_URI"]
+)
+
+await session_service.create_session(
+    app_name="my_app", user_id="user1", session_id="demo"
+)
+
+runner = Runner(app_name="my_app", agent=root_agent, session_service=session_service)
+
+async for event in runner.run_async(
+    user_id="user1",
+    session_id="demo",
+    new_message=content,
+):
+  if event.is_final_response():
+    print(event.content.parts[0].text)
+```
+
+If you already have an `AsyncMongoClient`, pass it instead of a connection
+string:
+
+```python
+from pymongo import AsyncMongoClient
+
+client = AsyncMongoClient(host="localhost", port=27017)
+session_service = MongoSessionService(client=client)
+```
+
+## Collections and indexing
+
+`MongoSessionService` writes to two collections (configurable):
+- `sessions`: conversation history and session-level state
+- `session_state`: shared app/user state across sessions
+
+Indexes are created on first use:
+- Unique session identity: `(app_name, user_id, id)`
+- Last update for recency queries: `(app_name, user_id, last_update_time)`
+
+## Sample structure
+
+```
+mongodb_service/
+├── main.py                    # Runs the sample with Mongo-backed sessions
+├── mongo_service_agent/
+│   ├── __init__.py            # Agent package init
+│   └── agent.py               # Financial advisor agent with two tools
+└── README.md                  # This file
+```
+
+## Sample agent
+
+The agent (`mongo_service_agent/agent.py`) includes:
+- `get_invoice_status(service)` tool for simple invoice lookups
+- `calculate_service_tax(amount)` tool for tax calculations
+- Gemini model (`gemini-2.0-flash`) with instructions to route to the tools
+
+## Sample query
+
+```
+What is the status of my university invoice? Also, calculate the tax for a service amount of 9500 MXN.
+```
+
+## Configuration options (`MongoSessionService`)
+
+- `database_name` (str, required): Mongo database to store session data
+- `connection_string` (str, optional): Mongo URI (mutually exclusive with `client`)
+- `client` (AsyncMongoClient, optional): Provide your own client/connection pool
+- `session_collection` (str, default `sessions`): Collection for session docs
+- `state_collection` (str, default `session_state`): Collection for shared state
+- `default_app_name` (str, optional): Fallback app name when not provided per call
+- `mongo_appname` (str, default `adk-cosmos-session-service`): App name tag for Mongo driver telemetry
+
+## Tips
+
+- Use `runner.run_async` (as in `main.py`) to keep the Mongo client on the same
+  event loop and avoid loop-bound client errors.
+- For production, prefer environment variables or secrets managers for the
+  connection string and database credentials.

--- a/contributing/samples/mongodb_service/README.md
+++ b/contributing/samples/mongodb_service/README.md
@@ -68,7 +68,7 @@ await session_service.create_session(
     app_name="my_app", user_id="user1", session_id="demo"
 )
 
-runner = Runner(app_name="my_app", agent=root_agent, session_service=session_service)
+runner = Runner(app_name="my_app", agent=your_agent, session_service=session_service)
 query = "Hello, can you help me with my account?"
 content = types.Content(role="user", parts=[types.Part(text=query)])
 

--- a/contributing/samples/mongodb_service/main.py
+++ b/contributing/samples/mongodb_service/main.py
@@ -19,6 +19,7 @@ import asyncio
 
 from google.adk.runners import Runner
 from google.genai import types
+from google.adk.errors.already_exists_error import AlreadyExistsError
 from mongo_service_agent import root_agent
 
 from google.adk_community.sessions import MongoSessionService
@@ -42,9 +43,13 @@ async def main():
   if not connection_string:
     raise ValueError("MONGODB_URI environment variable not set. See README.md for setup.")
   session_service = MongoSessionService(connection_string=connection_string)
-  await session_service.create_session(
-      app_name=APP_NAME, user_id=USER_ID, session_id=SESSION_ID
-  )
+  try:
+    await session_service.create_session(
+        app_name=APP_NAME, user_id=USER_ID, session_id=SESSION_ID
+    )
+  except AlreadyExistsError:
+    # Session already exists, which is fine for this example.
+    pass
 
   runner = Runner(
       agent=root_agent, app_name=APP_NAME, session_service=session_service

--- a/contributing/samples/mongodb_service/main.py
+++ b/contributing/samples/mongodb_service/main.py
@@ -14,12 +14,12 @@
 
 """Example of using MongoDB for Session Service."""
 
-import os
 import asyncio
+import os
 
+from google.adk.errors.already_exists_error import AlreadyExistsError
 from google.adk.runners import Runner
 from google.genai import types
-from google.adk.errors.already_exists_error import AlreadyExistsError
 from mongo_service_agent import root_agent
 
 from google.adk_community.sessions import MongoSessionService
@@ -31,7 +31,7 @@ SESSION_ID = "session_07"
 
 async def main():
   """Main function to run the agent asynchronously."""
-  
+
   #   You can create the MongoSessionService in two ways:
   #   1. With an existing AsyncMongoClient instance
   #   2. By providing a connection string directly
@@ -41,7 +41,9 @@ async def main():
 
   connection_string = os.environ.get("MONGODB_URI")
   if not connection_string:
-    raise ValueError("MONGODB_URI environment variable not set. See README.md for setup.")
+    raise ValueError(
+        "MONGODB_URI environment variable not set. See README.md for setup."
+    )
   session_service = MongoSessionService(connection_string=connection_string)
   try:
     await session_service.create_session(

--- a/contributing/samples/mongodb_service/main.py
+++ b/contributing/samples/mongodb_service/main.py
@@ -14,6 +14,7 @@
 
 """Example of using MongoDB for Session Service."""
 
+import os
 import asyncio
 
 from google.adk.runners import Runner
@@ -29,15 +30,18 @@ SESSION_ID = "session_07"
 
 async def main():
   """Main function to run the agent asynchronously."""
+  
   #   You can create the MongoSessionService in two ways:
   #   1. With an existing AsyncMongoClient instance
   #   2. By providing a connection string directly
   #   from pymongo import AsyncMongoClient
   #   client = AsyncMongoClient(host="localhost", port=27017)
   #   session_service = MongoSessionService(client=client)
-  session_service = MongoSessionService(
-      connection_string="mongodb+srv://<user>:<db_password>@<cluster-url>/"
-  )
+
+  connection_string = os.environ.get("MONGODB_URI")
+  if not connection_string:
+    raise ValueError("MONGODB_URI environment variable not set. See README.md for setup.")
+  session_service = MongoSessionService(connection_string=connection_string)
   await session_service.create_session(
       app_name=APP_NAME, user_id=USER_ID, session_id=SESSION_ID
   )

--- a/contributing/samples/mongodb_service/main.py
+++ b/contributing/samples/mongodb_service/main.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example of using MongoDB for Session Service."""
+
+import asyncio
+
+from google.adk.runners import Runner
+from google.genai import types
+from mongo_service_agent import root_agent
+
+from google.adk_community.sessions import MongoSessionService
+
+APP_NAME = "financial_advisor_agent"
+USER_ID = "juante_jc_11"
+SESSION_ID = "session_07"
+
+
+async def main():
+  """Main function to run the agent asynchronously."""
+  #   You can create the MongoSessionService in two ways:
+  #   1. With an existing AsyncMongoClient instance
+  #   2. By providing a connection string directly
+  #   from pymongo import AsyncMongoClient
+  #   client = AsyncMongoClient(host="localhost", port=27017)
+  #   session_service = MongoSessionService(client=client)
+  session_service = MongoSessionService(
+      connection_string="mongodb+srv://<user>:<db_password>@<cluster-url>/"
+  )
+  await session_service.create_session(
+      app_name=APP_NAME, user_id=USER_ID, session_id=SESSION_ID
+  )
+
+  runner = Runner(
+      agent=root_agent, app_name=APP_NAME, session_service=session_service
+  )
+
+  query = (
+      "What is the status of my university invoice? Also, calculate the tax for"
+      " a service amount of 9500 MXN."
+  )
+  print(f"User Query -> {query}")
+  content = types.Content(role="user", parts=[types.Part(text=query)])
+
+  async for event in runner.run_async(
+      user_id=USER_ID,
+      session_id=SESSION_ID,
+      new_message=content,
+  ):
+    if event.is_final_response():
+      print(f"Agent Response -> {event.content.parts[0].text}")
+
+
+if __name__ == "__main__":
+  asyncio.run(main())

--- a/contributing/samples/mongodb_service/mongo_service_agent/__init__.py
+++ b/contributing/samples/mongodb_service/mongo_service_agent/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .agent import root_agent

--- a/contributing/samples/mongodb_service/mongo_service_agent/agent.py
+++ b/contributing/samples/mongodb_service/mongo_service_agent/agent.py
@@ -16,17 +16,18 @@ from dotenv import load_dotenv
 from google.adk.agents import Agent
 from google.adk.tools import FunctionTool
 
-MODEL_ID = "gemini-2.0-flash"
-
 load_dotenv()
-
 
 # Tool 1
 def get_invoice_status(service: str) -> dict:
-  """Retrieves the status of invoices for a given service.
+  """Return the invoice status details for the requested service.
+
+  Args:
+    service: Business category to query (for example 'gas' or 'restaurant').
 
   Returns:
-  dict: A dictionary with invoice status details with a "status" key indicating the invoice status and a "report" key providing additional information.
+    dict: Contains a ``status`` entry with the invoice state and a ``report``
+      entry that gives the relevant context for that status.
   """
   if service == "university":
     return {"status": "success", "report": "All TEC invoices are paid."}
@@ -46,10 +47,14 @@ invoice_tool = FunctionTool(func=get_invoice_status)
 
 # Tool 2
 def calculate_service_tax(amount: float) -> dict:
-  """Calculates the tax for a given service amount.
+  """Calculate tax for a service amount using a fixed rate.
+
+  Args:
+    amount: Untaxed amount that needs a tax calculation.
 
   Returns:
-  dict: A dictionary with the original amount, calculated tax amount, and total amount including tax.
+    dict: Keys ``amount``, ``tax_amount``, and ``total_amount`` capturing the
+      original value, the computed tax, and the amount plus tax respectively.
   """
   tax_rate = 0.16
   tax_amount = amount * tax_rate
@@ -65,20 +70,18 @@ tax_tool = FunctionTool(func=calculate_service_tax)
 
 # Agent
 root_agent = Agent(
-    model=MODEL_ID,
+    model="gemini-2.0-flash",
     name="financial_advisor_agent",
-    description=(
-        "Financial advisor agent for managing invoices and calculating service taxes."
-    ),
+    description="Financial advisor agent for managing invoices and calculating service taxes.",
     instruction=(
-        "You are an AI agent designed to assist users with financial",
-        " inquiries related to invoices and service tax calculations.\n",
-        "**Available Tools:**\n",
+        "You are an AI agent designed to assist users with financial"
+        " inquiries related to invoices and service tax calculations.\n"
+        "**Available Tools:**\n"
         "1. get_invoice_status(service): Retrieves the status of invoices\n"
         "2. calculate_service_tax(amount): Calculates the tax for a given amount\n"
-        "Use these tools to assist users with their financial inquiries.\n",
-        "If the user asks about other financial topics, respond politely",
-        " that you can only assist with invoice status and tax calculations.\n",
+        "Use these tools to assist users with their financial inquiries.\n"
+        "If the user asks about other financial topics, respond politely"
+        " that you can only assist with invoice status and tax calculations.\n"
     ),
     tools=[invoice_tool, tax_tool],
 )

--- a/contributing/samples/mongodb_service/mongo_service_agent/agent.py
+++ b/contributing/samples/mongodb_service/mongo_service_agent/agent.py
@@ -1,0 +1,84 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dotenv import load_dotenv
+from google.adk.agents import Agent
+from google.adk.tools import FunctionTool
+
+MODEL_ID = "gemini-2.0-flash"
+
+load_dotenv()
+
+
+# Tool 1
+def get_invoice_status(service: str) -> dict:
+  """Retrieves the status of invoices for a given service.
+
+  Returns:
+  dict: A dictionary with invoice status details with a "status" key indicating the invoice status and a "report" key providing additional information.
+  """
+  if service == "university":
+    return {"status": "success", "report": "All TEC invoices are paid."}
+  elif service == "gas":
+    return {"status": "pending", "report": "Gas invoice due in 5 days."}
+  elif service == "restaurant":
+    return {
+        "status": "overdue",
+        "report": "Restaurant invoice is overdue by 10 days.",
+    }
+  else:
+    return {"status": "error", "report": "Service not recognized."}
+
+
+invoice_tool = FunctionTool(func=get_invoice_status)
+
+
+# Tool 2
+def calculate_service_tax(amount: float) -> dict:
+  """Calculates the tax for a given service amount.
+
+  Returns:
+  dict: A dictionary with the original amount, calculated tax amount, and total amount including tax.
+  """
+  tax_rate = 0.16
+  tax_amount = amount * tax_rate
+  total_amount = amount + tax_amount
+  return {
+      "amount": amount,
+      "tax_amount": tax_amount,
+      "total_amount": total_amount,
+  }
+
+
+tax_tool = FunctionTool(func=calculate_service_tax)
+
+# Agent
+root_agent = Agent(
+    model=MODEL_ID,
+    name="financial_advisor_agent",
+    description=(
+        "Financial advisor agent for managing invoices and calculating service taxes."
+    ),
+    instruction=(
+        "You are an AI agent designed to assist users with financial",
+        " inquiries related to invoices and service tax calculations.\n",
+        "**Available Tools:**\n",
+        "1. get_invoice_status(service): Retrieves the status of invoices\n"
+        "2. calculate_service_tax(amount): Calculates the tax for a given amount\n"
+        "Use these tools to assist users with their financial inquiries.\n",
+        "If the user asks about other financial topics, respond politely",
+        " that you can only assist with invoice status and tax calculations.\n",
+    ),
+    tools=[invoice_tool, tax_tool],
+)

--- a/contributing/samples/mongodb_service/mongo_service_agent/agent.py
+++ b/contributing/samples/mongodb_service/mongo_service_agent/agent.py
@@ -16,6 +16,8 @@ from dotenv import load_dotenv
 from google.adk.agents import Agent
 from google.adk.tools import FunctionTool
 
+
+_TAX_RATE = 0.16
 load_dotenv()
 
 # Tool 1
@@ -56,8 +58,7 @@ def calculate_service_tax(amount: float) -> dict:
     dict: Keys ``amount``, ``tax_amount``, and ``total_amount`` capturing the
       original value, the computed tax, and the amount plus tax respectively.
   """
-  tax_rate = 0.16
-  tax_amount = amount * tax_rate
+  tax_amount = amount * _TAX_RATE
   total_amount = amount + tax_amount
   return {
       "amount": amount,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
-  "pymongo>=4.15.4, <5.0.0" , # MongoDB for session storage
+  "pymongo>=4.15.4, <5.0.0", # MongoDB for session storage
   "redis>=5.0.0, <6.0.0", # Redis for session storage
   # go/keep-sorted end
   "orjson>=3.11.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
+  "pymongo>=4.15.4, <5.0.0" , # MongoDB for session storage
   "redis>=5.0.0, <6.0.0", # Redis for session storage
   # go/keep-sorted end
   "orjson>=3.11.3",

--- a/src/google/adk_community/sessions/__init__.py
+++ b/src/google/adk_community/sessions/__init__.py
@@ -14,6 +14,7 @@
 
 """Community session services for ADK."""
 
+from .mongo_session_service import MongoSessionService
 from .redis_session_service import RedisSessionService
 
-__all__ = ["RedisSessionService"]
+__all__ = ["RedisSessionService", "MongoSessionService"]

--- a/src/google/adk_community/sessions/__init__.py
+++ b/src/google/adk_community/sessions/__init__.py
@@ -17,4 +17,4 @@
 from .mongo_session_service import MongoSessionService
 from .redis_session_service import RedisSessionService
 
-__all__ = ["RedisSessionService", "MongoSessionService"]
+__all__ = ["MongoSessionService", "RedisSessionService"]

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -160,6 +160,8 @@ class MongoSessionService(BaseSessionService):
       filters["user_id"] = user_id
 
     cursor = self._sessions.find(filters, projection={"events": False})
+    # NOTE: BaseSessionService expects the full list to be returned, so we have
+    # to materialize the entire cursor which may load many sessions into memory.
     docs = await cursor.to_list(length=None)
 
     sessions: list[Session] = []

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -293,19 +293,20 @@ class MongoSessionService(BaseSessionService):
       self,
       app_name: str,
       user_id: str,
-      app_state_delta: dict[str, Any],
-      user_state_delta: dict[str, Any],
+      app_state_delta: Optional[dict[str, Any]],
+      user_state_delta: Optional[dict[str, Any]],
   ) -> None:
+    tasks = []
     if app_state_delta:
-      await self._update_state_document(
-          MongoKeys.app_state(app_name),
-          app_state_delta,
-      )
+      tasks.append(self._update_state_document(
+          MongoKeys.app_state(app_name), app_state_delta
+      ))
     if user_state_delta:
-      await self._update_state_document(
-          MongoKeys.user_state(app_name, user_id),
-          user_state_delta,
-      )
+      tasks.append(self._update_state_document(
+          MongoKeys.user_state(app_name, user_id), user_state_delta
+      ))
+    if tasks:
+      await asyncio.gather(*tasks)
 
   async def _update_state_document(
       self,

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -41,7 +41,7 @@ class MongoKeys:
 
   @staticmethod
   def session(app_name: str, user_id: str, session_id: str) -> str:
-    return f"session::{app_name}::{user_id}::{session_id}"
+    return f"session:{app_name}:{user_id}:{session_id}"
 
   @staticmethod
   def app_state(app_name: str) -> str:

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -1,0 +1,362 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import logging
+import time
+from typing import Any
+from typing import Optional
+import uuid
+
+from google.adk.errors.already_exists_error import AlreadyExistsError
+from google.adk.events import Event
+from google.adk.sessions import _session_util
+from google.adk.sessions import Session
+from google.adk.sessions import State
+from google.adk.sessions.base_session_service import BaseSessionService
+from google.adk.sessions.base_session_service import GetSessionConfig
+from google.adk.sessions.base_session_service import ListSessionsResponse
+from pymongo import ASCENDING
+from pymongo import AsyncMongoClient
+from pymongo import DESCENDING
+from pymongo.asynchronous.collection import AsyncCollection
+from pymongo.errors import DuplicateKeyError
+from typing_extensions import override
+
+logger = logging.getLogger("google_adk." + __name__)
+
+
+class MongoKeys:
+  """Helper to generate composite keys for Mongo-backed storage."""
+
+  @staticmethod
+  def session(app_name: str, user_id: str, session_id: str) -> str:
+    return f"session::{app_name}::{user_id}::{session_id}"
+
+  @staticmethod
+  def app_state(app_name: str) -> str:
+    return f"{State.APP_PREFIX}{app_name}"
+
+  @staticmethod
+  def user_state(app_name: str, user_id: str) -> str:
+    return f"{State.USER_PREFIX}{app_name}:{user_id}"
+
+
+class MongoSessionService(BaseSessionService):
+  """Session service backed by MongoDB."""
+
+  def __init__(
+      self,
+      client: Optional[AsyncMongoClient] = None,
+      connection_string: Optional[str] = None,
+      database_name: Optional[str] = "adk_sessions_db",
+      session_collection: str = "sessions",
+      state_collection: str = "session_state",
+      default_app_name: Optional[str] = "adk-mongo-session-service",
+  ) -> None:
+    if bool(connection_string) == bool(client):
+      raise ValueError(
+          "Provide either 'connection_string' or 'client', but not both."
+      )
+    self._client = client or AsyncMongoClient(connection_string)
+    self._sessions: AsyncCollection = self._client[database_name][
+        session_collection
+    ]
+    self._kv: AsyncCollection = self._client[database_name][state_collection]
+    self._default_app_name = default_app_name
+    self._indexes_built = False
+    self._indexes_lock = asyncio.Lock()
+
+  @override
+  async def create_session(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      state: Optional[dict[str, Any]] = None,
+      session_id: Optional[str] = None,
+  ) -> Session:
+    app_name = self._resolve_app_name(app_name)
+    await self._ensure_indexes()
+
+    session_id = (
+        session_id.strip()
+        if session_id and session_id.strip()
+        else str(uuid.uuid4())
+    )
+    doc_id = MongoKeys.session(app_name, user_id, session_id)
+
+    state_deltas = _session_util.extract_state_delta(state or {})
+    await self._apply_state_delta(
+        app_name, user_id, state_deltas["app"], state_deltas["user"]
+    )
+
+    session_doc = {
+        "_id": doc_id,
+        "app_name": app_name,
+        "user_id": user_id,
+        "id": session_id,
+        "state": state_deltas["session"] or {},
+        "events": [],
+        "last_update_time": time.time(),
+    }
+
+    try:
+      await self._sessions.insert_one(session_doc)
+    except DuplicateKeyError as exc:
+      raise AlreadyExistsError(
+          f"Session with id {session_id} already exists."
+      ) from exc
+
+    session = self._doc_to_session(session_doc)
+    return await self._merge_state(session)
+
+  @override
+  async def get_session(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      session_id: str,
+      config: Optional[GetSessionConfig] = None,
+  ) -> Optional[Session]:
+    app_name = self._resolve_app_name(app_name)
+    await self._ensure_indexes()
+
+    doc = await self._sessions.find_one({
+        "_id": MongoKeys.session(app_name, user_id, session_id),
+        "app_name": app_name,
+        "user_id": user_id,
+    })
+    if not doc:
+      return None
+
+    session = self._doc_to_session(doc)
+    session = self._apply_event_filters(session, config)
+    return await self._merge_state(session)
+
+  @override
+  async def list_sessions(
+      self,
+      *,
+      app_name: str,
+      user_id: Optional[str] = None,
+  ) -> ListSessionsResponse:
+    app_name = self._resolve_app_name(app_name)
+    await self._ensure_indexes()
+
+    filters: dict[str, Any] = {"app_name": app_name}
+    if user_id is not None:
+      filters["user_id"] = user_id
+
+    cursor = self._sessions.find(filters, projection={"events": False})
+    docs = await cursor.to_list(length=None)
+
+    sessions: list[Session] = []
+    for doc in docs:
+      doc.setdefault("events", [])
+      session = self._doc_to_session(doc)
+      merged = await self._merge_state(session)
+      merged.events = []
+      sessions.append(merged)
+
+    return ListSessionsResponse(sessions=sessions)
+
+  @override
+  async def delete_session(
+      self,
+      *,
+      app_name: str,
+      user_id: str,
+      session_id: str,
+  ) -> None:
+    app_name = self._resolve_app_name(app_name)
+    await self._ensure_indexes()
+
+    await self._sessions.delete_one(
+        {"_id": MongoKeys.session(app_name, user_id, session_id)}
+    )
+
+  @override
+  async def append_event(self, session: Session, event: Event) -> Event:
+    if event.partial:
+      return event
+
+    await self._ensure_indexes()
+
+    event = await super().append_event(session, event)
+    session.last_update_time = event.timestamp
+
+    state_delta = event.actions.state_delta if event.actions else None
+    state_deltas = _session_util.extract_state_delta(state_delta or {})
+
+    await self._apply_state_delta(
+        session.app_name,
+        session.user_id,
+        state_deltas["app"],
+        state_deltas["user"],
+    )
+
+    updates: dict[str, Any] = {
+        "$push": {"events": event.model_dump(mode="json", exclude_none=True)},
+        "$set": {"last_update_time": event.timestamp},
+    }
+
+    session_state_set = {
+        f"state.{key}": value
+        for key, value in state_deltas["session"].items()
+        if value is not None
+    }
+    session_state_unset = {
+        f"state.{key}": ""
+        for key, value in state_deltas["session"].items()
+        if value is None
+    }
+
+    if session_state_set:
+      updates.setdefault("$set", {}).update(session_state_set)
+    if session_state_unset:
+      updates["$unset"] = session_state_unset
+
+    result = await self._sessions.update_one(
+        {
+            "_id": MongoKeys.session(
+                session.app_name, session.user_id, session.id
+            )
+        },
+        updates,
+    )
+    if result.matched_count == 0:
+      logger.warning(
+          "Failed to append event: session %s/%s/%s not found in storage",
+          session.app_name,
+          session.user_id,
+          session.id,
+      )
+
+    return event
+
+  async def _ensure_indexes(self) -> None:
+    if self._indexes_built:
+      return
+    async with self._indexes_lock:
+      if self._indexes_built:
+        return
+      await self._sessions.create_index(
+          [("app_name", ASCENDING), ("user_id", ASCENDING), ("id", ASCENDING)],
+          unique=True,
+          name="session_identity_idx",
+      )
+      await self._sessions.create_index(
+          [
+              ("app_name", ASCENDING),
+              ("user_id", ASCENDING),
+              ("last_update_time", DESCENDING),
+          ],
+          name="session_last_update_idx",
+      )
+      self._indexes_built = True
+
+  async def _merge_state(self, session: Session) -> Session:
+    app_doc, user_doc = await asyncio.gather(
+        self._kv.find_one({"_id": MongoKeys.app_state(session.app_name)}),
+        self._kv.find_one(
+            {"_id": MongoKeys.user_state(session.app_name, session.user_id)}
+        ),
+    )
+
+    merged_state = dict(session.state)
+    if app_doc and app_doc.get("state"):
+      for key, value in app_doc["state"].items():
+        merged_state[State.APP_PREFIX + key] = value
+    if user_doc and user_doc.get("state"):
+      for key, value in user_doc["state"].items():
+        merged_state[State.USER_PREFIX + key] = value
+
+    return session.model_copy(update={"state": merged_state})
+
+  async def _apply_state_delta(
+      self,
+      app_name: str,
+      user_id: str,
+      app_state_delta: dict[str, Any],
+      user_state_delta: dict[str, Any],
+  ) -> None:
+    if app_state_delta:
+      await self._update_state_document(
+          MongoKeys.app_state(app_name),
+          app_state_delta,
+      )
+    if user_state_delta:
+      await self._update_state_document(
+          MongoKeys.user_state(app_name, user_id),
+          user_state_delta,
+      )
+
+  async def _update_state_document(
+      self,
+      key: str,
+      delta: dict[str, Any],
+  ) -> None:
+    set_ops = {
+        f"state.{key}": value
+        for key, value in delta.items()
+        if value is not None
+    }
+    unset_ops = {
+        f"state.{key}": "" for key, value in delta.items() if value is None
+    }
+
+    update: dict[str, Any] = {}
+    if set_ops:
+      update["$set"] = set_ops
+    if unset_ops:
+      update["$unset"] = unset_ops
+    if not update:
+      return
+
+    update.setdefault("$setOnInsert", {}).update({"_id": key})
+    await self._kv.update_one({"_id": key}, update, upsert=True)
+
+  def _apply_event_filters(
+      self, session: Session, config: Optional[GetSessionConfig]
+  ) -> Session:
+    if not config:
+      return session
+    events = session.events
+
+    if config.after_timestamp is not None:
+      events = [e for e in events if e.timestamp > config.after_timestamp]
+    if config.num_recent_events is not None:
+      events = events[-config.num_recent_events :]
+
+    return session.model_copy(update={"events": events})
+
+  def _doc_to_session(self, doc: dict[str, Any]) -> Session:
+    events = [Event.model_validate(e) for e in doc.get("events", [])]
+    return Session(
+        id=doc["id"],
+        app_name=doc["app_name"],
+        user_id=doc["user_id"],
+        state=doc.get("state", {}) or {},
+        events=events,
+        last_update_time=doc.get("last_update_time", 0.0),
+    )
+
+  def _resolve_app_name(self, app_name: Optional[str]) -> str:
+    resolved = app_name or self._default_app_name
+    if not resolved:
+      raise ValueError(
+          "app_name must be provided either in the call or in default_app_name."
+      )
+    return resolved

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -330,7 +330,6 @@ class MongoSessionService(BaseSessionService):
     if not update:
       return
 
-    update.setdefault("$setOnInsert", {}).update({"_id": key})
     await self._kv.update_one({"_id": key}, update, upsert=True)
 
   def _apply_event_filters(

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -170,10 +170,8 @@ class MongoSessionService(BaseSessionService):
 
     sessions: list[Session] = []
     for doc in docs:
-      doc.setdefault("events", [])
       session = self._doc_to_session(doc)
       merged = await self._merge_state(session)
-      merged.events = []
       sessions.append(merged)
 
     return ListSessionsResponse(sessions=sessions)

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -89,11 +89,7 @@ class MongoSessionService(BaseSessionService):
     app_name = self._resolve_app_name(app_name)
     await self._ensure_indexes()
 
-    session_id = (
-        session_id.strip()
-        if session_id and session_id.strip()
-        else str(uuid.uuid4())
-    )
+    session_id = (session_id or "").strip() or str(uuid.uuid4())
     doc_id = MongoKeys.session(app_name, user_id, session_id)
 
     state_deltas = _session_util.extract_state_delta(state or {})

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -161,6 +161,12 @@ class MongoSessionService(BaseSessionService):
     # NOTE: BaseSessionService expects the full list to be returned, so we have
     # to materialize the entire cursor which may load many sessions into memory.
     docs = await cursor.to_list(length=None)
+    if len(docs) > 1000:
+      logger.warning(
+          "Loading a large number of sessions (%d) into memory for app '%s'.",
+          len(docs),
+          app_name,
+      )
 
     sessions: list[Session] = []
     for doc in docs:

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -133,11 +133,9 @@ class MongoSessionService(BaseSessionService):
     app_name = self._resolve_app_name(app_name)
     await self._ensure_indexes()
 
-    doc = await self._sessions.find_one({
-        "_id": MongoKeys.session(app_name, user_id, session_id),
-        "app_name": app_name,
-        "user_id": user_id,
-    })
+    doc = await self._sessions.find_one(
+        {"_id": MongoKeys.session(app_name, user_id, session_id)}
+    )
     if not doc:
       return None
 
@@ -350,7 +348,7 @@ class MongoSessionService(BaseSessionService):
         id=doc["id"],
         app_name=doc["app_name"],
         user_id=doc["user_id"],
-        state=doc.get("state", {}) or {},
+        state=doc.get("state", {}),
         events=events,
         last_update_time=doc.get("last_update_time", 0.0),
     )

--- a/src/google/adk_community/sessions/mongo_session_service.py
+++ b/src/google/adk_community/sessions/mongo_session_service.py
@@ -59,7 +59,7 @@ class MongoSessionService(BaseSessionService):
       self,
       client: Optional[AsyncMongoClient] = None,
       connection_string: Optional[str] = None,
-      database_name: Optional[str] = "adk_sessions_db",
+      database_name: str = "adk_sessions_db",
       session_collection: str = "sessions",
       state_collection: str = "session_state",
       default_app_name: Optional[str] = "adk-mongo-session-service",

--- a/tests/unittests/sessions/test_mongo_session_service.py
+++ b/tests/unittests/sessions/test_mongo_session_service.py
@@ -78,8 +78,6 @@ class TestMongoSessionService:
     assert session is None
     sessions_collection.find_one.assert_awaited_once_with({
         "_id": MongoKeys.session("test_app", "test_user", "missing"),
-        "app_name": "test_app",
-        "user_id": "test_user",
     })
     assert service._indexes_built is True
 

--- a/tests/unittests/sessions/test_mongo_session_service.py
+++ b/tests/unittests/sessions/test_mongo_session_service.py
@@ -1,0 +1,282 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from google.adk.events import Event
+from google.adk.events.event_actions import EventActions
+from google.adk.sessions import State
+from google.adk.sessions.base_session_service import GetSessionConfig
+import pytest
+import pytest_asyncio
+
+from google.adk_community.sessions.mongo_session_service import MongoKeys
+from google.adk_community.sessions.mongo_session_service import MongoSessionService
+
+
+class TestMongoSessionService:
+  """Tests for MongoSessionService mirroring Redis coverage."""
+
+  @pytest_asyncio.fixture
+  async def mongo_service(self):
+    """Create a Mongo session service with mocked collections."""
+    sessions_collection = AsyncMock()
+    sessions_collection.create_index = AsyncMock()
+    sessions_collection.insert_one = AsyncMock()
+    sessions_collection.find_one = AsyncMock(return_value=None)
+    sessions_collection.find = MagicMock()
+    sessions_collection.delete_one = AsyncMock()
+    sessions_collection.update_one = AsyncMock(
+        return_value=MagicMock(matched_count=1)
+    )
+
+    kv_collection = AsyncMock()
+    kv_collection.find_one = AsyncMock(return_value=None)
+    kv_collection.update_one = AsyncMock()
+
+    db = MagicMock()
+
+    def _get_collection(name: str):
+      if name == "sessions":
+        return sessions_collection
+      if name == "session_state":
+        return kv_collection
+      raise KeyError(name)
+
+    db.__getitem__.side_effect = _get_collection
+
+    client = MagicMock()
+    client.__getitem__.return_value = db
+
+    service = MongoSessionService(database_name="test_db", client=client)
+    return service, sessions_collection, kv_collection
+
+  @pytest.mark.asyncio
+  async def test_get_empty_session(self, mongo_service):
+    """get_session should return None for missing sessions."""
+    service, sessions_collection, _ = mongo_service
+    sessions_collection.find_one.return_value = None
+
+    session = await service.get_session(
+        app_name="test_app", user_id="test_user", session_id="missing"
+    )
+
+    assert session is None
+    sessions_collection.find_one.assert_awaited_once_with({
+        "_id": MongoKeys.session("test_app", "test_user", "missing"),
+        "app_name": "test_app",
+        "user_id": "test_user",
+    })
+    assert service._indexes_built is True
+
+  @pytest.mark.asyncio
+  async def test_create_and_get_session(self, mongo_service):
+    """create_session persists and get_session retrieves a session."""
+    service, sessions_collection, kv_collection = mongo_service
+    kv_collection.find_one.return_value = None
+
+    session = await service.create_session(
+        app_name="test_app",
+        user_id="test_user",
+        session_id="session-1",
+        state={"key": "value"},
+    )
+
+    inserted_doc = sessions_collection.insert_one.await_args.args[0]
+    assert inserted_doc["_id"] == MongoKeys.session(
+        "test_app", "test_user", "session-1"
+    )
+    assert inserted_doc["state"] == {"key": "value"}
+
+    sessions_collection.find_one.return_value = dict(inserted_doc)
+
+    retrieved = await service.get_session(
+        app_name="test_app", user_id="test_user", session_id="session-1"
+    )
+
+    assert retrieved is not None
+    assert retrieved.id == "session-1"
+    assert retrieved.app_name == session.app_name
+    assert retrieved.user_id == session.user_id
+    assert retrieved.state["key"] == "value"
+
+    # Indexes should only be created once even when called from multiple methods.
+    assert sessions_collection.create_index.await_count == 2
+
+  @pytest.mark.asyncio
+  async def test_list_sessions_merges_state_and_strips_events(
+      self, mongo_service
+  ):
+    """list_sessions returns sessions without events but with merged state."""
+    service, sessions_collection, kv_collection = mongo_service
+    app_name = "test_app"
+    user_id = "user1"
+
+    docs = [
+        {
+            "_id": MongoKeys.session(app_name, user_id, "s1"),
+            "app_name": app_name,
+            "user_id": user_id,
+            "id": "s1",
+            "state": {"session_key": "v1"},
+            "events": [{"author": "user", "timestamp": 1.0}],
+        },
+        {
+            "_id": MongoKeys.session(app_name, user_id, "s2"),
+            "app_name": app_name,
+            "user_id": user_id,
+            "id": "s2",
+            "state": {"session_key": "v2"},
+        },
+    ]
+
+    cursor = MagicMock()
+    cursor.to_list = AsyncMock(return_value=docs)
+    sessions_collection.find.return_value = cursor
+
+    async def _kv_find_one(query):
+      if query["_id"] == MongoKeys.app_state(app_name):
+        return {"_id": query["_id"], "state": {"theme": "dark"}}
+      if query["_id"] == MongoKeys.user_state(app_name, user_id):
+        return {"_id": query["_id"], "state": {"pref": "value"}}
+      return None
+
+    kv_collection.find_one.side_effect = _kv_find_one
+
+    response = await service.list_sessions(app_name=app_name, user_id=user_id)
+
+    assert len(response.sessions) == 2
+    for doc, sess in zip(docs, response.sessions):
+      assert sess.id == doc["id"]
+      assert sess.events == []
+      assert sess.state["session_key"] == doc["state"]["session_key"]
+      assert sess.state[State.APP_PREFIX + "theme"] == "dark"
+      assert sess.state[State.USER_PREFIX + "pref"] == "value"
+
+  @pytest.mark.asyncio
+  async def test_session_state_management_on_append_event(self, mongo_service):
+    """append_event should persist state deltas and mutate in-memory session."""
+    service, sessions_collection, kv_collection = mongo_service
+    app_name = "test_app"
+    user_id = "test_user"
+    session_id = "session-123"
+    kv_collection.find_one.return_value = None
+
+    session = await service.create_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        state={"initial_key": "initial_value"},
+    )
+
+    event = Event(
+        invocation_id="invocation",
+        author="user",
+        timestamp=datetime.now().astimezone(timezone.utc).timestamp(),
+        actions=EventActions(
+            state_delta={
+                f"{State.APP_PREFIX}key": "app_value",
+                f"{State.USER_PREFIX}key1": "user_value",
+                "temp:key": "temp_value",
+                "initial_key": "updated_value",
+            }
+        ),
+    )
+
+    await service.append_event(session=session, event=event)
+
+    assert session.state[State.APP_PREFIX + "key"] == "app_value"
+    assert session.state[State.USER_PREFIX + "key1"] == "user_value"
+    assert session.state["initial_key"] == "updated_value"
+    assert session.state.get("temp:key") is None
+
+    # App and user deltas are stored in the kv collection.
+    assert kv_collection.update_one.await_count == 2
+    kv_update_filters = [
+        call.args[0] for call in kv_collection.update_one.await_args_list
+    ]
+    kv_updates = [
+        call.args[1] for call in kv_collection.update_one.await_args_list
+    ]
+    assert {"_id": MongoKeys.app_state(app_name)} in kv_update_filters
+    assert {"_id": MongoKeys.user_state(app_name, user_id)} in kv_update_filters
+    assert any(
+        update.get("$set", {}).get("state.key") == "app_value"
+        for update in kv_updates
+    )
+    assert any(
+        update.get("$set", {}).get("state.key1") == "user_value"
+        for update in kv_updates
+    )
+
+    update_filter, update_doc = sessions_collection.update_one.await_args.args
+    assert update_filter == {
+        "_id": MongoKeys.session(app_name, user_id, session_id)
+    }
+    assert update_doc["$set"]["state.initial_key"] == "updated_value"
+    # Temp state should not be persisted.
+    assert "state.temp:key" not in update_doc.get("$set", {})
+    if "$unset" in update_doc:
+      assert "state.temp:key" in update_doc["$unset"]
+
+  @pytest.mark.asyncio
+  async def test_get_session_with_config(self, mongo_service):
+    """get_session applies after_timestamp and num_recent_events filters."""
+    service, sessions_collection, kv_collection = mongo_service
+    kv_collection.find_one.return_value = None
+
+    events = [
+        Event(author="user", timestamp=float(i)).model_dump(
+            mode="json", exclude_none=True
+        )
+        for i in range(1, 6)
+    ]
+    doc = {
+        "_id": MongoKeys.session("app", "user", "session"),
+        "app_name": "app",
+        "user_id": "user",
+        "id": "session",
+        "events": events,
+        "state": {},
+    }
+
+    sessions_collection.find_one.return_value = doc
+
+    config = GetSessionConfig(num_recent_events=3)
+    filtered = await service.get_session(
+        app_name="app", user_id="user", session_id="session", config=config
+    )
+    assert [e.timestamp for e in filtered.events] == [3.0, 4.0, 5.0]
+
+    config = GetSessionConfig(after_timestamp=3.0)
+    filtered = await service.get_session(
+        app_name="app", user_id="user", session_id="session", config=config
+    )
+    assert [e.timestamp for e in filtered.events] == [4.0, 5.0]
+
+  @pytest.mark.asyncio
+  async def test_delete_session(self, mongo_service):
+    """delete_session removes session documents."""
+    service, sessions_collection, _ = mongo_service
+
+    await service.delete_session(
+        app_name="test_app", user_id="user", session_id="session-1"
+    )
+
+    sessions_collection.delete_one.assert_awaited_once_with(
+        {"_id": MongoKeys.session("test_app", "user", "session-1")}
+    )

--- a/tests/unittests/sessions/test_mongo_session_service.py
+++ b/tests/unittests/sessions/test_mongo_session_service.py
@@ -131,7 +131,6 @@ class TestMongoSessionService:
             "user_id": user_id,
             "id": "s1",
             "state": {"session_key": "v1"},
-            "events": [{"author": "user", "timestamp": 1.0}],
         },
         {
             "_id": MongoKeys.session(app_name, user_id, "s2"),
@@ -156,6 +155,10 @@ class TestMongoSessionService:
     kv_collection.find_one.side_effect = _kv_find_one
 
     response = await service.list_sessions(app_name=app_name, user_id=user_id)
+
+    sessions_collection.find.assert_called_once_with(
+        {"app_name": app_name, "user_id": user_id}, projection={"events": False}
+    )
 
     assert len(response.sessions) == 2
     for doc, sess in zip(docs, response.sessions):

--- a/tests/unittests/sessions/test_mongo_session_service.py
+++ b/tests/unittests/sessions/test_mongo_session_service.py
@@ -231,8 +231,7 @@ class TestMongoSessionService:
     assert update_doc["$set"]["state.initial_key"] == "updated_value"
     # Temp state should not be persisted.
     assert "state.temp:key" not in update_doc.get("$set", {})
-    if "$unset" in update_doc:
-      assert "state.temp:key" in update_doc["$unset"]
+    assert "state.temp:key" not in update_doc.get("$unset", {})
 
   @pytest.mark.asyncio
   async def test_get_session_with_config(self, mongo_service):


### PR DESCRIPTION
# MongoDB Session Service Implementation
This pull request addresses the issue described in #31

It introduces a new MongoDB-backed session service for managing user sessions and conversation history in the ADK Community project.

## What's Changed
### New MongoDB-backed session service:
- Added a new `MongoSessionService` class that provides a MongoDB-backed implementation of session management, including methods for creating, retrieving, listing, and deleting sessions, as well as managing session state and events (`src/google/adk_community/sessions/mongo_session_service.py`)
- Updated `__init__.py` in the sessions module to include `MongoSessionService` in the exports (`src/google/adk_community/sessions/__init__.py`)

### Dependency updates:
- Added `"pymongo>=4.15.4, <5.0.0"` as a new dependency in pyproject.toml to support the MongoDB-based session service.

## MongoDB Data Persistence Verification
MongoDB Compass shows the successfully written session data and conversation history, confirming that:

- Session data is correctly serialized and stored in MongoDB
- Conversation history is properly maintained across requests
- Data structure aligns with expected MongoDB document patterns

> Screenshot of terminal output after running agent example with session service enabled:
<img width="1060" height="410" alt="terminal_test" src="https://github.com/user-attachments/assets/25c84d3e-679a-432e-b13c-e21bec71867c" />

> Screenshot of MongoDB Compass displaying session data:
<img width="1573" height="845" alt="mongo_validation" src="https://github.com/user-attachments/assets/e57e78a0-243f-4bb3-8a56-d3f9cede7cd2" />

## Checklist
- [x] We have read the `CONTRIBUTING.md` document
- [x] We have added tests that prove my feature works
- [x] New and existing unit tests pass locally with the changes
- [x] Code follows ADK style guide and conventions