### PR TITLE
Fix Redis User Session Key and Add Comprehensive Testing

### DIFF
--- a/contributing/samples/redis_session_service/README.md
+++ b/contributing/samples/redis_session_service/README.md
@@ -1,0 +1,302 @@
+# Redis Session Service Sample
+
+This sample demonstrates how to use Redis as a session storage backend for ADK agents using the community package.
+
+## Prerequisites
+
+- Python 3.9+ (Python 3.11+ recommended)
+- Redis server running locally or remotely
+- ADK and ADK Community installed
+
+## Setup
+
+### 1. Install Dependencies
+
+```bash
+pip install google-adk google-adk-community
+```
+
+### 2. Set Up Redis Server
+
+#### Option A: Using Homebrew (macOS)
+
+```bash
+brew install redis
+brew services start redis
+```
+
+#### Option B: Using Docker
+
+```bash
+docker run -d -p 6379:6379 redis:latest
+```
+
+#### Option C: Using apt (Ubuntu/Debian)
+
+```bash
+sudo apt-get install redis-server
+sudo systemctl start redis-server
+```
+
+Once Redis is running, verify the connection:
+
+```bash
+redis-cli ping
+# Should return: PONG
+```
+
+### 3. Configure Environment Variables
+
+Create a `.env` file in this directory:
+
+```bash
+# Required: Google API key for the agent
+GOOGLE_API_KEY=your-google-api-key
+
+# Required: Redis connection URI
+REDIS_URI=redis://localhost:6379
+```
+
+**Note:** The default Redis URI assumes Redis is running locally on port 6379. Adjust if your Redis instance is running elsewhere.
+
+## Usage
+
+### Running the Sample
+
+The simplest way to use this sample is to run the included `main.py`:
+
+```bash
+python main.py
+```
+
+This will start a FastAPI web server on `http://localhost:8080` with:
+- A web interface for interacting with the weather assistant agent
+- Redis-backed session persistence
+- Session TTL (Time To Live) of 1 hour
+- Health check endpoint at `/health`
+
+The `main.py` file demonstrates how to:
+- Register the Redis session service with the service registry
+- Use `get_fast_api_app` to create a FastAPI application with Redis session support
+- Configure session expiration and CORS settings
+- Serve the web interface for agent interaction
+
+### Using get_fast_api_app with Redis
+
+```python
+import os
+import uvicorn
+from google.adk.cli.fast_api import get_fast_api_app
+
+# Configure application
+AGENTS_DIR = "./redis_service_agent"
+SESSION_SERVICE_URI = "redis://localhost:6379/0"
+ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8080", "*"]
+
+# Create FastAPI app with Redis session service
+app = get_fast_api_app(
+    agents_dir=AGENTS_DIR,
+    session_service_uri=SESSION_SERVICE_URI,
+    session_db_kwargs=dict(expire=60 * 60 * 1),  # 1 hour TTL
+    artifact_service_uri="",
+    allow_origins=ALLOWED_ORIGINS,
+    web=True,
+)
+
+# Add custom endpoints if needed
+@app.get("/health")
+async def get_health():
+    return {"status": "ok"}
+
+# Run the server
+uvicorn.run(app, host="0.0.0.0", port=8080)
+```
+
+### Direct RedisSessionService Usage
+
+You can also use `RedisSessionService` directly without FastAPI:
+
+```python
+from google.adk_community.sessions import RedisSessionService
+from google.adk.runners import Runner
+from google.adk.errors.already_exists_error import AlreadyExistsError
+from google.adk.agents import Agent
+from google.genai import types
+
+# Define your agent (example)
+my_agent = Agent(
+    model="gemini-2.5-flash",
+    name="my_assistant",
+    description="A helpful assistant",
+    instruction="You are a helpful assistant.",
+)
+
+# Create Redis session service
+redis_uri = "redis://localhost:6379"
+session_service = RedisSessionService(uri=redis_uri)
+
+# Create a session
+APP_NAME = "weather_assistant"
+USER_ID = "user_123"
+SESSION_ID = "session_01"
+
+try:
+    await session_service.create_session(
+        app_name=APP_NAME,
+        user_id=USER_ID,
+        session_id=SESSION_ID
+    )
+except AlreadyExistsError:
+    # Session already exists, which is fine
+    pass
+
+# Use with runner
+runner = Runner(
+    agent=my_agent,  # Your agent instance
+    app_name=APP_NAME,
+    session_service=session_service
+)
+
+# Prepare user message
+query = "What's the weather like today?"
+user_message = types.Content(
+    role="user",
+    parts=[types.Part(text=query)]
+)
+
+# Run agent queries
+async for event in runner.run_async(
+    user_id=USER_ID,
+    session_id=SESSION_ID,
+    new_message=user_message,
+):
+    if event.is_final_response():
+        print(event.content.parts[0].text)
+```
+
+## Sample Structure
+
+```
+redis_session_service/
+├── main.py                        # FastAPI app with Redis session service
+├── redis_service_agent/
+│   ├── __init__.py                # Agent package initialization
+│   ├── agent.py                   # Simple weather assistant agent
+│   └── services.py                # Redis service registry setup
+├── .env                           # Environment variables (create this)
+└── README.md                      # This file
+```
+
+## Sample Agent
+
+The sample agent (`redis_service_agent/agent.py`) is a simple weather assistant that includes:
+- A `get_weather` tool that returns weather information for cities
+- Basic agent configuration using Gemini 2.5 Flash
+
+This is a minimal example to demonstrate Redis session persistence without complexity.
+
+## Service Registration
+
+The `services.py` file registers the Redis session service with the ADK service registry:
+
+```python
+from google.adk.cli.service_registry import get_service_registry
+from google.adk_community.sessions.redis_session_service import RedisSessionService
+
+def redis_session_factory(uri: str, **kwargs):
+    kwargs_copy = kwargs.copy()
+    kwargs_copy.pop("agents_dir", None)
+    return RedisSessionService(uri=uri, **kwargs_copy)
+
+get_service_registry().register_session_service("redis", redis_session_factory)
+```
+
+This registration allows `get_fast_api_app` to automatically create a Redis session service when a `redis://` URI is provided.
+
+## Interacting with the Sample
+
+Once the server is running, you can:
+
+1. **Use the Web Interface**: Navigate to `http://localhost:8080` in your browser to interact with the weather assistant through the web UI.
+
+2. **Make API Calls**: Send requests to the API endpoints programmatically.
+
+3. **Check Health**: Visit `http://localhost:8080/health` to verify the server is running.
+
+Example queries to try:
+- "What's the weather like in San Francisco and Tokyo?"
+- "How's the weather in New York?"
+- "Tell me about London's weather conditions"
+
+All conversation history is stored in Redis with a 1-hour TTL, so you can have multi-turn conversations and the agent will remember the context.
+
+## Configuration Options
+
+### Redis URI Format
+
+The `REDIS_URI` environment variable supports various Redis connection formats:
+
+- `redis://localhost:6379` - Local Redis instance (default)
+- `redis://username:password@host:port` - Redis with authentication
+- `rediss://host:port` - Redis with TLS/SSL
+- `redis://host:port/db_number` - Specify Redis database number
+
+### FastAPI Configuration Options
+
+When using `get_fast_api_app`, you can customize behavior:
+
+```python
+app = get_fast_api_app(
+    agents_dir="./redis_service_agent",
+    session_service_uri="redis://localhost:6379/0",
+    session_db_kwargs=dict(
+        expire=60 * 60 * 24,  # Session TTL in seconds (24 hours)
+    ),
+    artifact_service_uri="",  # Optional artifact storage URI
+    allow_origins=["*"],  # CORS allowed origins
+    web=True,  # Enable web interface
+)
+```
+
+### RedisSessionService Options
+
+When creating the `RedisSessionService` directly, you can customize behavior:
+
+```python
+session_service = RedisSessionService(
+    uri="redis://localhost:6379",
+    expire=3600,  # Session TTL in seconds (1 hour)
+)
+```
+
+## Features
+
+Redis Session Service provides:
+
+- **Persistent session storage**: Conversation history survives application restarts
+- **Multi-session support**: Handle multiple users and sessions simultaneously
+- **Fast performance**: In-memory data structure store for quick access
+- **Scalability**: Redis can be clustered for high-availability deployments
+- **Simple setup**: Works with existing Redis infrastructure
+
+## Troubleshooting
+
+### Connection Issues
+
+If you see connection errors:
+1. Verify Redis is running: `redis-cli ping`
+2. Check your `REDIS_URI` is correct
+3. Ensure no firewall is blocking port 6379
+
+### Session Already Exists
+
+The sample handles `AlreadyExistsError` gracefully. If you want to start fresh:
+```bash
+redis-cli FLUSHDB
+```
+
+## Learn More
+
+- [Redis Documentation](https://redis.io/docs/)
+- [ADK Session Documentation](https://google.github.io/adk-docs)
+- [ADK Community Repository](https://github.com/google/adk-python-community)

--- a/contributing/samples/redis_session_service/README.md
+++ b/contributing/samples/redis_session_service/README.md
@@ -13,7 +13,7 @@ This sample demonstrates how to use Redis as a session storage backend for ADK a
 ### 1. Install Dependencies
 
 ```bash
-pip install google-adk google-adk-community
+pip install google-adk-community[redis]
 ```
 
 ### 2. Set Up Redis Server
@@ -109,7 +109,7 @@ async def get_health():
     return {"status": "ok"}
 
 # Run the server
-uvicorn.run(app, host="0.0.0.0", port=8080)
+uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
 ```
 
 ### Direct RedisSessionService Usage
@@ -117,7 +117,7 @@ uvicorn.run(app, host="0.0.0.0", port=8080)
 You can also use `RedisSessionService` directly without FastAPI:
 
 ```python
-from google.adk_community.sessions import RedisSessionService
+from google.adk_community.sessions.redis_session_service import RedisSessionService
 from google.adk.runners import Runner
 from google.adk.errors.already_exists_error import AlreadyExistsError
 from google.adk.agents import Agent

--- a/contributing/samples/redis_session_service/example.env
+++ b/contributing/samples/redis_session_service/example.env
@@ -1,0 +1,2 @@
+REDIS_URI=redis://localhost:6379
+GOOGLE_API_KEY=your_api_key_here

--- a/contributing/samples/redis_session_service/main.py
+++ b/contributing/samples/redis_session_service/main.py
@@ -1,0 +1,48 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example of using Redis for Session Service with FastAPI."""
+
+import os
+import uvicorn
+
+from google.adk.cli.fast_api import get_fast_api_app
+
+AGENTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "redis_service_agent")
+SESSION_SERVICE_URI = os.environ.get("REDIS_URI", "redis://127.0.0.1:6379/0")
+ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8080", "*"]
+SERVE_WEB_INTERFACE = True
+ARTIFACT_SERVICE_URI = ""
+
+
+def main():
+    """Main function to run the FastAPI application."""
+    app = get_fast_api_app(
+        agents_dir=AGENTS_DIR,
+        session_service_uri=SESSION_SERVICE_URI,
+        session_db_kwargs=dict(expire=60 * 60 * 1),  # 1 hour of Time To Live
+        artifact_service_uri=ARTIFACT_SERVICE_URI,
+        allow_origins=ALLOWED_ORIGINS,
+        web=SERVE_WEB_INTERFACE,
+    )
+
+    @app.get("/health")
+    async def get_health():
+        return {"status": "ok"}
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
+
+
+if __name__ == "__main__":
+    main()

--- a/contributing/samples/redis_session_service/redis_service_agent/__init__.py
+++ b/contributing/samples/redis_session_service/redis_service_agent/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .agent import root_agent

--- a/contributing/samples/redis_session_service/redis_service_agent/agent.py
+++ b/contributing/samples/redis_session_service/redis_service_agent/agent.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dotenv import load_dotenv
+from google.adk.agents import Agent
+from google.adk.tools.function_tool import FunctionTool
+
+
+load_dotenv()
+
+
+def get_weather(city: str) -> dict:
+    """Get the current weather for a city.
+
+    Parameters:
+    -----------
+    city: str
+        The name of the city to get weather for.
+
+    Returns:
+    --------
+    dict: Contains weather information for the city.
+    """
+    weather_data = {
+        "San Francisco": {"temperature": 18, "condition": "Foggy"},
+        "New York": {"temperature": 22, "condition": "Sunny"},
+        "London": {"temperature": 15, "condition": "Rainy"},
+        "Tokyo": {"temperature": 25, "condition": "Clear"},
+    }
+
+    if city in weather_data:
+        return weather_data[city]
+    else:
+        return {"temperature": 20, "condition": "Unknown"}
+
+
+weather_tool = FunctionTool(func=get_weather)
+
+root_agent = Agent(
+    model="gemini-2.5-flash",
+    name="weather_assistant",
+    description="A simple weather assistant that provides weather information.",
+    instruction=(
+        "You are a helpful weather assistant. "
+        "Use the get_weather tool to provide weather information for cities. "
+        "Be friendly and concise in your responses."
+    ),
+    tools=[weather_tool],
+)

--- a/contributing/samples/redis_session_service/redis_service_agent/services.py
+++ b/contributing/samples/redis_session_service/redis_service_agent/services.py
@@ -1,0 +1,11 @@
+from google.adk.cli.service_registry import get_service_registry
+from google.adk_community.sessions.redis_session_service import RedisSessionService
+
+
+def redis_session_factory(uri: str, **kwargs):
+    kwargs_copy = kwargs.copy()
+    kwargs_copy.pop("agents_dir", None)
+    return RedisSessionService(uri=uri, **kwargs_copy)
+
+
+get_service_registry().register_session_service("redis", redis_session_factory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ dependencies = [
   "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
-  "redis>=5.0.0, <6.0.0", # Redis for session storage
+  "redis >= 7.0.0", # Redis for session storage
   # go/keep-sorted end
-  "orjson>=3.11.3",
+  "orjson>=3.11.4",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,7 @@ dependencies = [
   "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
-  "redis >= 7.0.0", # Redis for session storage
   # go/keep-sorted end
-  "orjson>=3.11.4",
 ]
 dynamic = ["version"]
 
@@ -41,9 +39,13 @@ changelog = "https://github.com/google/adk-python-community/blob/main/CHANGELOG.
 documentation = "https://google.github.io/adk-docs/"
 
 [project.optional-dependencies]
+redis = [
+  "redis>=7.0.0", # Redis for session storage
+  "orjson>=3.11.4", # Fast JSON serialization for Redis
+]
 test = [
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.2.0",
+  "pytest>=8.4.2",
+  "pytest-asyncio>=1.2.0",
 ]
 
 
@@ -72,8 +74,8 @@ build-backend = "flit_core.buildapi"
 
 [dependency-groups]
 dev = [
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.2.0",
+  "pytest>=8.4.2",
+  "pytest-asyncio>=1.2.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ s3 = [
     "aioboto3>=13.0.0",  # For S3ArtifactService
 ]
 test = [
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.2.0",
+  "pytest>=8.4.2",
+  "pytest-asyncio>=1.2.0",
 ]
 sdc-agents = [
     "sdc-agents>=4.3.3; python_version >= '3.11'",
@@ -78,8 +78,8 @@ build-backend = "flit_core.buildapi"
 
 [dependency-groups]
 dev = [
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.2.0",
+  "pytest>=8.4.2",
+  "pytest-asyncio>=1.2.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ dependencies = [
   # go/keep-sorted start
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
-  "orjson>=3.11.3",
-  "redis>=5.0.0, <6.0.0", # Redis for session storage
-  # go/keep-sorted end
 ]
 dynamic = ["version"]
 
@@ -39,6 +36,10 @@ changelog = "https://github.com/google/adk-python-community/blob/main/CHANGELOG.
 documentation = "https://google.github.io/adk-docs/"
 
 [project.optional-dependencies]
+redis = [
+  "redis >= 7.0.0", # Redis for session storage
+  "orjson>=3.11.4", # Fast JSON serialization for Redis
+]
 s3 = [
     "aioboto3>=13.0.0",  # For S3ArtifactService
 ]

--- a/src/google/adk_community/sessions/redis_session_service.py
+++ b/src/google/adk_community/sessions/redis_session_service.py
@@ -55,7 +55,7 @@ class RedisKeys:
 
     @staticmethod
     def user_sessions(app_name: str, user_id: str) -> str:
-        return f"{State.APP_PREFIX}:{app_name}:{user_id}"
+        return f"{State.APP_PREFIX}{app_name}:{user_id}"
 
     @staticmethod
     def app_state(app_name: str) -> str:

--- a/src/google/adk_community/sessions/redis_session_service.py
+++ b/src/google/adk_community/sessions/redis_session_service.py
@@ -20,10 +20,17 @@ import time
 import uuid
 from typing import Any, Optional
 
-import orjson
-import redis.asyncio as redis
-from redis.crc import key_slot
 from typing_extensions import override
+
+try:
+    import orjson
+    import redis.asyncio as redis
+    from redis.crc import key_slot
+except ImportError as exc:
+    raise ImportError(
+        "redis and orjson are required to use RedisSessionService. "
+        "Install it with: pip install google-adk-community[redis]"
+    ) from exc
 
 from google.adk.events.event import Event
 from google.adk.sessions.base_session_service import (

--- a/tests/unittests/sessions/test_redis_session_service.py
+++ b/tests/unittests/sessions/test_redis_session_service.py
@@ -22,6 +22,7 @@ from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
 from google.adk.sessions.base_session_service import GetSessionConfig
 from google.adk_community.sessions.redis_session_service import RedisSessionService
+from google.adk.cli.fast_api import get_fast_api_app
 from google.genai import types
 
 
@@ -558,3 +559,37 @@ class TestRedisSessionService:
         assert session is not None
         assert session.app_name == app_name
         assert session.user_id == user_id
+
+    @pytest.mark.asyncio
+    async def test_get_fast_api_app_with_redis_uri(self, monkeypatch):
+        """Test get_fast_api_app integration with Redis URI."""
+        from google.adk.cli.service_registry import get_service_registry
+
+        def redis_session_factory(uri: str, **kwargs):
+            kwargs_copy = kwargs.copy()
+            kwargs_copy.pop("agents_dir", None)
+            return RedisSessionService(uri=uri, **kwargs_copy)
+
+        service_registry = get_service_registry()
+        monkeypatch.setitem(
+            service_registry._session_factories, "redis", redis_session_factory
+        )
+
+        with patch("redis.asyncio.Redis.from_url") as mock_redis:
+            mock_client = AsyncMock()
+            mock_client.ping = AsyncMock(return_value=True)
+            mock_redis.return_value = mock_client
+
+            redis_uri = "redis://localhost:6379"
+            app = get_fast_api_app(
+                agents_dir=".",
+                session_service_uri=redis_uri,
+                web=False,
+            )
+
+            assert app is not None
+            assert hasattr(app, "routes")
+
+            mock_redis.assert_called_once()
+            call_args = mock_redis.call_args
+            assert redis_uri in str(call_args)


### PR DESCRIPTION
# Fix Redis User Session Key and Add Comprehensive Testing

This pull request addresses the issue described in https://github.com/google/adk-python-community/issues/34.

This pull request addresses a bug in the Redis session key generation and adds comprehensive testing and examples to improve the Redis session service reliability and community adoption.

## What's Changed

### Bug Fix: Double Colon in User Session Keys
- Fixed incorrect key pattern in `RedisKeys.user_sessions()` method that was generating keys with double colons (`::`) instead of single colons (`:`)
- Changed from `f"{State.APP_PREFIX}:{app_name}:{user_id}"` to `f"{State.APP_PREFIX}{app_name}:{user_id}"` in `src/google/adk_community/sessions/redis_session_service.py`
- This ensures consistent key naming across all Redis keys and improves maintainability

### Comprehensive Testing and Examples
- Added complete Redis session service sample in `contributing/samples/redis_session_service/` to demonstrate proper usage for the community
- Includes a simple weather assistant agent (`regis_service_agent/`) to showcase session persistence without complexity
- Added comprehensive README with setup instructions, usage examples, and troubleshooting guide
- Added unit test for FastAPI integration with Redis URI (`test_get_fast_api_app_with_redis_uri` in `tests/unittests/sessions/test_redis_session_service.py`)

### Dependency Updates
- Updated `redis` dependency from `>=5.0.0, <6.0.0` to `>= 7.0.0` in `pyproject.toml` for better compatibility
- Updated `orjson` from `>=3.11.3` to `>=3.11.4`

## Sample Structure

The new sample demonstrates real-world usage with FastAPI integration:

```
contributing/samples/redis_session_service/
├── main.py                        # FastAPI app with Redis session service
├── redis_service_agent/
│   ├── __init__.py                # Agent package initialization
│   ├── agent.py                   # Simple weather assistant agent
│   └── services.py                # Redis service registry setup
├── .env                           # Environment configuration (create this)
└── README.md                      # Comprehensive documentation
```

## Usage Example

The sample demonstrates the recommended approach using `get_fast_api_app` with the service registry pattern:

```python
import os
import uvicorn
from google.adk.cli.fast_api import get_fast_api_app

# The services.py module registers Redis session service
# This allows get_fast_api_app to automatically use it
AGENTS_DIR = os.path.dirname(os.path.abspath(__file__)) + "/regis_service_agent"
SESSION_SERVICE_URI = os.environ.get("REDIS_URI", "redis://127.0.0.1:6379/0")
ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8080", "*"]

# Create FastAPI app with Redis session service
app = get_fast_api_app(
    agents_dir=AGENTS_DIR,
    session_service_uri=SESSION_SERVICE_URI,
    session_db_kwargs=dict(expire=60 * 60 * 1),  # 1 hour TTL
    artifact_service_uri="",
    allow_origins=ALLOWED_ORIGINS,
    web=True,  # Enable web interface
)

@app.get("/health")
async def get_health():
    return {"status": "ok"}

# Run the server
uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
```

### Service Registry Setup

The `services.py` file shows how to register Redis session service:

```python
from google.adk.cli.service_registry import get_service_registry
from google.adk_community.sessions.redis_session_service import RedisSessionService

def redis_session_factory(uri: str, **kwargs):
    kwargs_copy = kwargs.copy()
    kwargs_copy.pop("agents_dir", None)
    return RedisSessionService(uri=uri, **kwargs_copy)

get_service_registry().register_session_service("redis", redis_session_factory)
```

## Testing

### Unit Tests
- Added test coverage for `get_fast_api_app` integration with Redis URI

### Running the Sample

```bash
# Install dependencies
pip install git+https://github.com/yvesemmanuel/adk-python-community.git@fix/redis-user-session-id

# Start Redis (if not already running)
brew services start redis  # macOS
# or
docker run -d -p 6379:6379 redis:latest

# Set up environment
export GOOGLE_API_KEY=your-api-key
export REDIS_URI=redis://localhost:6379/0

# Run the sample (starts FastAPI server)
cd contributing/samples/redis_session_service
python main.py
```

The server will start on `http://localhost:8080` with:
- Web interface for interacting with the weather assistant
- Health check endpoint at `/health`
- Redis-backed session storage with 1-hour TTL

## Community Impact

The sample serves as both documentation and a production-ready starting point for developers integrating Redis session storage into their ADK applications. It follows the official ADK patterns and demonstrates proper service registry usage, making it easier for the community to build scalable agent applications with persistent session storage.