### PR TITLE
Feat/38 firestore memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   # go/keep-sorted start
   "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
+  "google-cloud-firestore", # Firestore client library
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
   "redis>=5.0.0, <6.0.0", # Redis for session storage
   # go/keep-sorted end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ classifiers = [ # List of https://pypi.org/classifiers/
 ]
 dependencies = [
   # go/keep-sorted start
-  "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "google-adk", # Google ADK
   "google-cloud-firestore", # Firestore client library
+  "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK  
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
   "redis>=5.0.0, <6.0.0", # Redis for session storage
   # go/keep-sorted end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   # go/keep-sorted start
   "google-adk", # Google ADK
   "google-cloud-firestore", # Firestore client library
-  "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK  
+  "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
   "redis>=5.0.0, <6.0.0", # Redis for session storage
   # go/keep-sorted end

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -110,12 +110,11 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         async with Aclosing(llm.generate_content_async(request)) as agen:
             response_text_parts = []
             async for response in agen:
-                if (
-                    response.content
-                    and response.content.parts
-                    and response.content.parts[0].text
-                ):
-                    response_text_parts.append(response.content.parts[0].text)
+                if response.content:
+                    for part in response.content.parts:
+                        if part.text:
+                            response_text_parts.append(part.text)
+
             return "".join(response_text_parts)
 
     def _parse_llm_json_response(self, content: str) -> Any | None:

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -147,7 +147,8 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         existing_facts = []
         async for doc in facts_ref.stream():
             data = doc.to_dict()
-            existing_facts.append({"id": doc.id, "text": data["text"]})
+            if data and "text" in data:
+                existing_facts.append({"id": doc.id, "text": data["text"]})
 
         # 2. Reconcile with the Agent
         session_text = self._format_session(session)

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -230,6 +230,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
             self.db.collection(self.collection_name)
             .document(user_key)
             .collection("facts")
+            .order_by("timestamp", direction=firestore.Query.DESCENDING)
             .limit(limit)
         )
 

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -223,7 +223,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         self, *, app_name: str, user_id: str, query: str, limit: int = 100
     ) -> SearchMemoryResponse:
         """
-            Uses the Agent to find relevant facts based on the query.
+        Uses the Agent to find relevant facts based on the query.
         Args:
             app_name: The application name.
             user_id: The user ID.

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -174,7 +174,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
 
         content = await self._call_agent(prompt)
         operations = self._parse_llm_json_response(content)
-        if not operations:
+        if not operations or not isinstance(operations, dict):
             logger.warning(
                 f"No valid operations returned from Agent for session {session.id}."
             )

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -1,0 +1,257 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+from typing_extensions import override
+
+import google.auth
+from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
+from google.genai import types
+
+from google.adk.agents.llm_agent import Agent
+from google.adk.models.llm_request import LlmRequest
+from google.adk.utils.context_utils import Aclosing
+from google.adk.memory import _utils
+from google.adk.memory.base_memory_service import BaseMemoryService
+from google.adk.memory.base_memory_service import SearchMemoryResponse
+from google.adk.memory.memory_entry import MemoryEntry
+
+if TYPE_CHECKING:
+    from google.adk.events.event import Event
+    from google.adk.sessions.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+class FirestoreLLMMemoryService(BaseMemoryService):
+    """A Firestore-based memory service that uses an LLM to manage facts.
+
+    Instead of storing raw events, it extracts and reconciles concise facts
+    about the user, enabling smarter semantic search and memory management.
+    """
+
+    def __init__(
+        self,
+        collection_name: str = "agent_facts",
+        model: str = "gemini-2.0-flash",
+        database: Optional[
+            str
+        ] = "(default)",  # use generous free tier default by default
+    ):
+        """Initializes the FirestoreLLMMemoryService.
+
+        Args:
+            collection_name: The root collection name in Firestore.
+            model: The LLM model to use for memory management.
+            database: The Firestore database to use. (Uses free tier by default)
+        """
+        credentials, project_id = google.auth.default()
+        self.db = firestore.AsyncClient(
+            credentials=credentials, project=project_id, database=database
+        )
+        self.collection_name = collection_name
+
+        # The internal agent dedicated to managing the memory state.
+        self._memory_agent = Agent(
+            model=model,
+            name="memory_manager",
+            description="Manages user facts and retrieves relevant memories.",
+            instruction=(
+                "You are a memory management assistant. Your job is to maintain a high-quality "
+                "list of facts about conversations. "
+                "You will be asked to reconcile new conversations with existing facts "
+                "and to retrieve relevant facts based on queries."
+            ),
+        )
+
+    def _format_session(self, session: Session) -> str:
+        lines = []
+        for event in session.events:
+            if not event.content or not event.content.parts:
+                continue
+            text = " ".join([p.text for p in event.content.parts if p.text])
+            lines.append(f"{event.author}: {text}")
+        return "\n".join(lines)
+
+    async def _call_agent(self, prompt: str) -> str:
+        """Utility to call the underlying LLM of the agent."""
+        llm = self._memory_agent.canonical_model
+        request = LlmRequest(model=llm.model)
+
+        # Add system instruction from agent
+        if isinstance(self._memory_agent.instruction, str):
+            request.append_instructions([self._memory_agent.instruction])
+
+        # Add user prompt
+        request.contents.append(
+            types.Content(role="user", parts=[types.Part(text=prompt)])
+        )
+
+        async with Aclosing(llm.generate_content_async(request)) as agen:
+            final_response = None
+            async for response in agen:
+                if not response.partial:
+                    final_response = response
+
+            if (
+                final_response
+                and final_response.content
+                and final_response.content.parts
+                and final_response.content.parts[0].text
+            ):
+                return final_response.content.parts[0].text
+        return ""
+
+    @override
+    async def add_session_to_memory(self, session: Session):
+        """Extracts facts from the session and updates Firestore."""
+        user_key = f"{session.app_name}:{session.user_id}"
+        facts_ref = (
+            self.db.collection(self.collection_name)
+            .document(user_key)
+            .collection("facts")
+        )
+
+        # 1. Fetch existing facts
+        existing_facts = []
+        async for doc in facts_ref.stream():
+            data = doc.to_dict()
+            existing_facts.append({"id": doc.id, "text": data["text"]})
+
+        # 2. Reconcile with the Agent
+        session_text = self._format_session(session)
+        prompt = (
+            f"Existing Facts:\n{json.dumps(existing_facts, indent=2)}\n\n"
+            f"New Session Transcript:\n{session_text}\n\n"
+            "Task: Reconcile the new session with the existing facts. "
+            "Identify facts to add, update, or delete. "
+            "Respond ONLY with a JSON object in this format:\n"
+            '{"add": ["new fact text"], "update": [{"id": "doc_id", "text": "new text"}], "delete": ["doc_id"]}'
+        )
+
+        content = await self._call_agent(prompt)
+        try:
+            # Clean up potential markdown formatting in response
+            content = content.strip()
+            if content.startswith("```json"):
+                content = content[7:-3].strip()
+            elif content.startswith("```"):
+                content = content[3:-3].strip()
+
+            operations = json.loads(content)
+        except Exception as e:
+            logger.error(
+                f"Failed to parse Agent response for fact reconciliation: {e}. Response: {content}"
+            )
+            return
+
+        # 3. Apply operations to Firestore
+        batch = self.db.batch()
+
+        for fact_text in operations.get("add", []):
+            new_doc_ref = facts_ref.document()
+            batch.set(
+                new_doc_ref,
+                {
+                    "text": fact_text,
+                    "timestamp": firestore.SERVER_TIMESTAMP,
+                    "source_session_id": session.id,
+                },
+            )
+
+        for update in operations.get("update", []):
+            doc_ref = facts_ref.document(update["id"])
+            batch.update(
+                doc_ref,
+                {
+                    "text": update["text"],
+                    "timestamp": firestore.SERVER_TIMESTAMP,
+                    "source_session_id": session.id,
+                },
+            )
+
+        for doc_id in operations.get("delete", []):
+            batch.delete(facts_ref.document(doc_id))
+
+        await batch.commit()
+
+    @override
+    async def search_memory(
+        self, *, app_name: str, user_id: str, query: str
+    ) -> SearchMemoryResponse:
+        """Uses the Agent to find relevant facts based on the query."""
+        user_key = f"{app_name}:{user_id}"
+        facts_ref = (
+            self.db.collection(self.collection_name)
+            .document(user_key)
+            .collection("facts")
+        )
+
+        # 1. Fetch all facts
+        all_facts = []
+        async for doc in facts_ref.stream():
+            data = doc.to_dict()
+            all_facts.append(
+                {
+                    "id": doc.id,
+                    "text": data["text"],
+                    "timestamp": data.get("timestamp").timestamp(),
+                    "source_session_id": data.get("source_session_id"),
+                }
+            )
+
+        if not all_facts:
+            return SearchMemoryResponse()
+
+        # 2. Filter with the Agent
+        prompt = (
+            f"User Query: {query}\n\n"
+            f"Available Facts:\n{json.dumps(all_facts, indent=2, default=str)}\n\n"
+            "Task: Identify which facts are relevant to the user query. "
+            "Respond ONLY with a JSON list of IDs of the relevant facts. "
+            'Example: ["id1", "id2"]'
+        )
+
+        content = await self._call_agent(prompt)
+        try:
+            content = content.strip()
+            if content.startswith("```json"):
+                content = content[7:-3].strip()
+            elif content.startswith("```"):
+                content = content[3:-3].strip()
+            relevant_ids = json.loads(content)
+        except Exception as e:
+            logger.error(
+                f"Failed to parse Agent response for memory search: {e}. Response: {content}"
+            )
+            return SearchMemoryResponse()
+
+        # 3. Construct response
+        search_response = SearchMemoryResponse()
+        relevant_facts = [f for f in all_facts if f["id"] in relevant_ids]
+        for fact in relevant_facts:
+            search_response.memories.append(
+                MemoryEntry(
+                    content=types.Content(parts=[types.Part(text=fact["text"])]),
+                    author="memory_manager",
+                    timestamp=_utils.format_timestamp(fact["timestamp"]),
+                )
+            )
+
+        return search_response

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -108,19 +108,11 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         )
 
         async with Aclosing(llm.generate_content_async(request)) as agen:
-            final_response = None
+            response_text_parts = []
             async for response in agen:
-                if not response.partial:
-                    final_response = response
-
-            if (
-                final_response
-                and final_response.content
-                and final_response.content.parts
-                and final_response.content.parts[0].text
-            ):
-                return final_response.content.parts[0].text
-        return ""
+                if response.content and response.content.parts and response.content.parts[0].text:
+                    response_text_parts.append(response.content.parts[0].text)
+            return "".join(response_text_parts)
 
     def _parse_llm_json_response(self, content: str) -> Any | None:
         """Utility to strip markdown and parse JSON from LLM response, with error logging."""

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -209,14 +209,22 @@ class FirestoreLLMMemoryService(BaseMemoryService):
 
     @override
     async def search_memory(
-        self, *, app_name: str, user_id: str, query: str
+        self, *, app_name: str, user_id: str, query: str, limit: int = 100
     ) -> SearchMemoryResponse:
-        """Uses the Agent to find relevant facts based on the query."""
+        """
+            Uses the Agent to find relevant facts based on the query.
+        Args:
+            app_name: The application name.
+            user_id: The user ID.
+            query: The search query.
+            limit: Maximum number of facts to consider.
+        """
         user_key = f"{app_name}:{user_id}"
         facts_ref = (
             self.db.collection(self.collection_name)
             .document(user_key)
             .collection("facts")
+            .limit(limit)
         )
 
         # 1. Fetch all facts

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -134,13 +134,14 @@ class FirestoreLLMMemoryService(BaseMemoryService):
             return None
 
     @override
-    async def add_session_to_memory(self, session: Session):
+    async def add_session_to_memory(self, session: Session, limit: int = 100):
         """Extracts facts from the session and updates Firestore."""
         user_key = f"{session.app_name}:{session.user_id}"
         facts_ref = (
             self.db.collection(self.collection_name)
             .document(user_key)
             .collection("facts")
+            .limit(limit)
         )
 
         # 1. Fetch existing facts

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -214,11 +214,13 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         all_facts = []
         async for doc in facts_ref.stream():
             data = doc.to_dict()
+            timestamp_obj = data.get("timestamp")
+            timestamp = timestamp_obj.timestamp() if timestamp_obj else None
             all_facts.append(
                 {
                     "id": doc.id,
-                    "text": data["text"],
-                    "timestamp": data.get("timestamp").timestamp(),
+                    "text": data.get("text"),
+                    "timestamp": timestamp,
                     "source_session_id": data.get("source_session_id"),
                 }
             )

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -59,6 +59,8 @@ class FirestoreLLMMemoryService(BaseMemoryService):
             collection_name: The root collection name in Firestore.
             model: The LLM model to use for memory management.
             database: The Firestore database to use. (Uses free tier by default)
+            reconciliation_limit: The maximum number of recent facts to consider
+                during reconciliation.
         """
         credentials, project_id = google.auth.default()
         self.db = firestore.AsyncClient(

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -110,7 +110,11 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         async with Aclosing(llm.generate_content_async(request)) as agen:
             response_text_parts = []
             async for response in agen:
-                if response.content and response.content.parts and response.content.parts[0].text:
+                if (
+                    response.content
+                    and response.content.parts
+                    and response.content.parts[0].text
+                ):
                     response_text_parts.append(response.content.parts[0].text)
             return "".join(response_text_parts)
 
@@ -246,7 +250,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         all_facts = []
         async for doc in facts_ref.stream():
             data = doc.to_dict()
-            if not data:
+            if not data or not data.get("text"):
                 continue
             timestamp_obj = data.get("timestamp")
             timestamp = timestamp_obj.timestamp() if timestamp_obj else 0

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 from typing_extensions import override
 
 import google.auth

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -21,7 +21,6 @@ from typing_extensions import override
 
 import google.auth
 from google.cloud import firestore
-from google.cloud.firestore_v1.base_query import FieldFilter
 from google.genai import types
 
 from google.adk.agents.llm_agent import Agent

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -281,7 +281,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
 
         # 3. Construct response
         search_response = SearchMemoryResponse()
-        relevant_facts = [f for f in all_facts if f["id"] in set(relevant_ids)]
+        relevant_facts = [f for f in all_facts if f["id"] in set(map(str, relevant_ids))]
         for fact in relevant_facts:
             search_response.memories.append(
                 MemoryEntry(

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -193,7 +193,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
                 )
 
         for update in operations.get("update", []):
-            if isinstance(update, dict) and "id" in update and "text" in update:
+            if isinstance(update, dict) and isinstance(update.get("id"), str) and isinstance(update.get("text"), str):
                 all_ops.append(
                     (
                         "UPDATE",

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -281,7 +281,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
 
         content = await self._call_agent(prompt)
         relevant_ids = self._parse_llm_json_response(content)
-        if not relevant_ids:
+        if not relevant_ids or not isinstance(relevant_ids, list):
             return SearchMemoryResponse()
 
         # 3. Construct response

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -127,9 +127,9 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         try:
             content = content.strip()
             if content.startswith("```json"):
-                content = content[7:-3].strip()
+                content = content.removeprefix("```json").removesuffix("```").strip()
             elif content.startswith("```"):
-                content = content[3:-3].strip()
+                content = content.removeprefix("```").removesuffix("```").strip()
             return json.loads(content)
         except json.JSONDecodeError as e:
             logger.error(

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -193,7 +193,6 @@ class FirestoreLLMMemoryService(BaseMemoryService):
 
         for update in operations.get("update", []):
             if isinstance(update, dict) and "id" in update and "text" in update:
-                logger.info(f"UPDATE FACT: {update}")
                 doc_ref = facts_collection_ref.document(update["id"])
                 batch.update(
                     doc_ref,

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -172,29 +172,32 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         batch = self.db.batch()
 
         for fact_text in operations.get("add", []):
-            new_doc_ref = facts_ref.document()
-            batch.set(
-                new_doc_ref,
-                {
-                    "text": fact_text,
-                    "timestamp": firestore.SERVER_TIMESTAMP,
-                    "source_session_id": session.id,
-                },
-            )
+            if isinstance(fact_text, str):
+                new_doc_ref = facts_ref.document()
+                batch.set(
+                    new_doc_ref,
+                    {
+                        "text": fact_text,
+                        "timestamp": firestore.SERVER_TIMESTAMP,
+                        "source_session_id": session.id,
+                    },
+                )
 
         for update in operations.get("update", []):
-            doc_ref = facts_ref.document(update["id"])
-            batch.update(
-                doc_ref,
-                {
-                    "text": update["text"],
-                    "timestamp": firestore.SERVER_TIMESTAMP,
-                    "source_session_id": session.id,
-                },
-            )
+            if isinstance(update, dict) and "id" in update and "text" in update:
+                doc_ref = facts_ref.document(update["id"])
+                batch.update(
+                    doc_ref,
+                    {
+                        "text": update["text"],
+                        "timestamp": firestore.SERVER_TIMESTAMP,
+                        "source_session_id": session.id,
+                    },
+                )
 
         for doc_id in operations.get("delete", []):
-            batch.delete(facts_ref.document(doc_id))
+            if isinstance(doc_id, str):
+                batch.delete(facts_ref.document(doc_id))
 
         await batch.commit()
 

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -144,7 +144,9 @@ class FirestoreLLMMemoryService(BaseMemoryService):
             .collection("facts")
         )
         # get a subset of existing facts to reconcile against
-        facts_ref = facts_collection_ref.limit(limit)
+        facts_ref = facts_collection_ref.order_by(
+            "timestamp", direction=firestore.Query.DESCENDING
+        ).limit(limit)
 
         # 1. Fetch existing facts
         existing_facts = []

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -234,6 +234,8 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         all_facts = []
         async for doc in facts_ref.stream():
             data = doc.to_dict()
+            if not data:
+                continue
             timestamp_obj = data.get("timestamp")
             timestamp = timestamp_obj.timestamp() if timestamp_obj else 0
             all_facts.append(

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -263,7 +263,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
 
         # 3. Construct response
         search_response = SearchMemoryResponse()
-        relevant_facts = [f for f in all_facts if f["id"] in relevant_ids]
+        relevant_facts = [f for f in all_facts if f["id"] in set(relevant_ids)]
         for fact in relevant_facts:
             search_response.memories.append(
                 MemoryEntry(

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -211,6 +211,8 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         )
 
         # 1. Fetch all facts
+        # Note: If expecting a large number of facts,
+        # consider vector search (would require embedding cloud function, etc.)
         all_facts = []
         async for doc in facts_ref.stream():
             data = doc.to_dict()

--- a/src/google/adk_community/memory/firestore_llm_memory_service.py
+++ b/src/google/adk_community/memory/firestore_llm_memory_service.py
@@ -215,7 +215,7 @@ class FirestoreLLMMemoryService(BaseMemoryService):
         async for doc in facts_ref.stream():
             data = doc.to_dict()
             timestamp_obj = data.get("timestamp")
-            timestamp = timestamp_obj.timestamp() if timestamp_obj else None
+            timestamp = timestamp_obj.timestamp() if timestamp_obj else 0
             all_facts.append(
                 {
                     "id": doc.id,

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -105,8 +105,7 @@ class FirestoreWordMemoryService(BaseMemoryService):
                         )
                     ),
                 }
-                # Using timestamp or a hash of content as ID if event doesn't have one
-                # Base ADK Event might not have a unique ID, so we use a generated one or timestamp
+                # Add to batch with firestore-generated ID
                 batch.set(events_ref.document(), event_data)
         if has_events_to_add:
             await batch.commit()

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 def _extract_words_lower(text: str) -> set[str]:
     """Extracts words from a string and converts them to lowercase."""
-    return set([word.lower() for word in re.findall(r"[A-Za-z]+", text)])
+    return set([word.lower() for word in re.findall(r"\w+", text)])
 
 
 class FirestoreWordMemoryService(BaseMemoryService):

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 def _extract_words_lower(text: str) -> set[str]:
     """Extracts words from a string and converts them to lowercase."""
-    return set([word.lower() for word in re.findall(r"\w+", text)])
+    return {word.lower() for word in re.findall(r"\w+", text)}
 
 
 class FirestoreWordMemoryService(BaseMemoryService):

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -51,10 +51,11 @@ class FirestoreWordMemoryService(BaseMemoryService):
             str
         ] = "(default)",  # use generous free tier default by default
     ):
-        """Initializes the FirestoreMemoryService.
+        """Initializes the FirestoreWordMemoryService.
 
         Args:
             collection_name: The root collection name in Firestore.
+            database: The Firestore database to use. (Uses free tier by default)
         """
         credentials, project_id = google.auth.default()
         self.db = firestore.AsyncClient(

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -113,7 +113,7 @@ class FirestoreWordMemoryService(BaseMemoryService):
 
     @override
     async def search_memory(
-        self, *, app_name: str, user_id: str, query: str
+        self, *, app_name: str, user_id: str, query: str, limit: int = 100
     ) -> SearchMemoryResponse:
         """Searches memory in Firestore based on keyword matching."""
         user_key = f"{app_name}:{user_id}"
@@ -145,9 +145,13 @@ class FirestoreWordMemoryService(BaseMemoryService):
             )
             query_words_list = query_words_list[:30]
 
-        docs = events_query.where(
-            filter=FieldFilter("words", "array_contains_any", query_words_list)
-        ).stream()
+        docs = (
+            events_query.where(
+                filter=FieldFilter("words", "array_contains_any", query_words_list)
+            )
+            .limit(limit)
+            .stream()
+        )
 
         async for doc in docs:
             data = doc.to_dict()

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -1,0 +1,146 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Optional, Any
+from typing_extensions import override
+
+from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
+from google.genai import types
+from google.adk.memory import _utils
+from google.adk.memory.base_memory_service import BaseMemoryService
+from google.adk.memory.base_memory_service import SearchMemoryResponse
+from google.adk.memory.memory_entry import MemoryEntry
+import google.auth
+
+if TYPE_CHECKING:
+    from google.adk.events.event import Event
+    from google.adk.sessions.session import Session
+
+
+def _extract_words_lower(text: str) -> set[str]:
+    """Extracts words from a string and converts them to lowercase."""
+    return set([word.lower() for word in re.findall(r"[A-Za-z]+", text)])
+
+
+class FirestoreWordMemoryService(BaseMemoryService):
+    """A Firestore-based memory service for Google ADK.
+
+    Uses Google Cloud Firestore to store and retrieve memories.
+    Matches the keyword-based search behavior of InMemoryMemoryService.
+    """
+
+    def __init__(
+        self,
+        collection_name: str = "agent_memories",
+        database: Optional[
+            str
+        ] = "(default)",  # use generous free tier default by default
+    ):
+        """Initializes the FirestoreMemoryService.
+
+        Args:
+            collection_name: The root collection name in Firestore.
+        """
+        credentials, project_id = google.auth.default()
+        self.db = firestore.AsyncClient(
+            credentials=credentials, project=project_id, database=database
+        )
+        self.collection_name = collection_name
+
+    def _serialize_content(self, content: types.Content) -> dict[str, Any]:
+        if not content or not content.parts:
+            return {"parts": []}
+        return {"parts": [{"text": part.text} for part in content.parts if part.text]}
+
+    def _deserialize_content(self, data: dict[str, Any]) -> types.Content:
+        parts = [types.Part(text=p["text"]) for p in data.get("parts", [])]
+        return types.Content(parts=parts)
+
+    @override
+    async def add_session_to_memory(self, session: Session):
+        """Adds all events from a session to Firestore memory."""
+        # We store events in a subcollection under a user document
+        # Structure: {collection_name}/{app_name}:{user_id}/events/{event_id}
+
+        user_key = f"{session.app_name}:{session.user_id}"
+        user_ref = self.db.collection(self.collection_name).document(user_key)
+        events_ref = user_ref.collection("events")
+
+        for event in session.events:
+            if event.content and event.content.parts:
+                event_data = {
+                    "session_id": session.id,
+                    "content": self._serialize_content(event.content),
+                    "author": event.author,
+                    "timestamp": event.timestamp,
+                    # We pre-calculate words for easier filtering if needed,
+                    # though we still do filtering in search_memory to match InMemory behavior
+                    "words": list(
+                        _extract_words_lower(
+                            " ".join(
+                                [part.text for part in event.content.parts if part.text]
+                            )
+                        )
+                    ),
+                }
+                # Using timestamp or a hash of content as ID if event doesn't have one
+                # Base ADK Event might not have a unique ID, so we use a generated one or timestamp
+                await events_ref.add(event_data)
+
+    @override
+    async def search_memory(
+        self, *, app_name: str, user_id: str, query: str
+    ) -> SearchMemoryResponse:
+        """Searches memory in Firestore based on keyword matching."""
+        user_key = f"{app_name}:{user_id}"
+        words_in_query = _extract_words_lower(query)
+        response = SearchMemoryResponse()
+
+        if not words_in_query:
+            return response
+
+        # Structure for events to make searching easier while keeping user context.
+        # Structure: {collection_name}/{user_key}/events/{event_id}
+
+        events_query = (
+            self.db.collection(self.collection_name)
+            .document(user_key)
+            .collection("events")
+        )
+
+        # We can attempt to filter by query words using array_contains_any
+        # This matches the 'any(query_word in words_in_event for query_word in words_in_query)' logic
+        query_words_list = list(words_in_query)
+
+        # Firestore array_contains_any handles up to 30 elements
+        # If query is longer, we might need multiple queries or client-side filtering
+        docs = events_query.where(
+            filter=FieldFilter("words", "array_contains_any", query_words_list)
+        ).stream()
+
+        async for doc in docs:
+            data = doc.to_dict()
+            response.memories.append(
+                MemoryEntry(
+                    content=self._deserialize_content(data["content"]),
+                    author=data["author"],
+                    timestamp=_utils.format_timestamp(data["timestamp"]),
+                )
+            )
+
+        return response

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -32,10 +32,58 @@ if TYPE_CHECKING:
     from google.adk.sessions.session import Session
 logger = logging.getLogger(__name__)
 
+# Basic set of stop words to filter out from keyword indexing
+STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "am",
+    "as",
+    "at",
+    "any",
+    "be",
+    "by",
+    "but",
+    "for",
+    "from",
+    "had",
+    "has",
+    "have",
+    "he",
+    "her",
+    "his",
+    "i",
+    "if",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "she",
+    "the",
+    "them",
+    "then",
+    "there",
+    "these",
+    "they",
+    "to",
+    "us",
+    "you",
+    "your",
+    "we",
+    "were",
+    "with",
+}
+
 
 def _extract_words_lower(text: str) -> set[str]:
-    """Extracts words from a string and converts them to lowercase."""
-    return {word.lower() for word in re.findall(r"\w+", text)}
+    """Extracts words from a string and converts them to lowercase, filtering stop words."""
+    return {
+        word.lower()
+        for word in re.findall(r"\w+", text)
+        if word.lower() not in STOP_WORDS
+    }
 
 
 class FirestoreWordMemoryService(BaseMemoryService):

--- a/src/google/adk_community/memory/firestore_word_memory_service.py
+++ b/src/google/adk_community/memory/firestore_word_memory_service.py
@@ -144,12 +144,19 @@ class FirestoreWordMemoryService(BaseMemoryService):
 
         async for doc in docs:
             data = doc.to_dict()
-            response.memories.append(
-                MemoryEntry(
-                    content=self._deserialize_content(data["content"]),
-                    author=data["author"],
-                    timestamp=_utils.format_timestamp(data["timestamp"]),
+            if (
+                data
+                and data.get("content")
+                and data.get("author")
+                and data.get("timestamp")
+            ):
+
+                response.memories.append(
+                    MemoryEntry(
+                        content=self._deserialize_content(data["content"]),
+                        author=data["author"],
+                        timestamp=_utils.format_timestamp(data["timestamp"]),
+                    )
                 )
-            )
 
         return response

--- a/tests/unittests/memory/test_firestore_llm_memory_service.py
+++ b/tests/unittests/memory/test_firestore_llm_memory_service.py
@@ -216,5 +216,4 @@ class TestFirestoreLLMMemoryService:
 
         # Verify that no commit happened because no valid operations were found
         mock_batch = mock_firestore.batch.return_value
-        print(f"\nMock batch commit call count: {mock_batch.commit.call_count}")
         assert mock_batch.commit.call_count == 0

--- a/tests/unittests/memory/test_firestore_llm_memory_service.py
+++ b/tests/unittests/memory/test_firestore_llm_memory_service.py
@@ -109,7 +109,7 @@ class TestFirestoreLLMMemoryService:
         # 2. Mock LLM Response
         llm_response_json = {
             "add": ["Likes hiking"],
-            "update": [{"id": "fact-1", "text": "Actually hates hiking"}],
+            "update": [{"id": "fact-1", "text": "Actually dislikes hiking"}],
             "delete": [],
         }
 

--- a/tests/unittests/memory/test_firestore_llm_memory_service.py
+++ b/tests/unittests/memory/test_firestore_llm_memory_service.py
@@ -63,6 +63,7 @@ def mock_firestore():
         mock_client.collection.return_value = mock_collection
         mock_collection.document.return_value = mock_document
         mock_document.collection.return_value = mock_subcollection
+        mock_subcollection.limit.return_value = mock_subcollection
 
         # Batch mock
         mock_batch = MagicMock()

--- a/tests/unittests/memory/test_firestore_llm_memory_service.py
+++ b/tests/unittests/memory/test_firestore_llm_memory_service.py
@@ -1,0 +1,195 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import json
+import pytest
+
+from google.adk.events.event import Event
+from google.adk.sessions.session import Session
+from google.adk_community.memory.firestore_llm_memory_service import (
+    FirestoreLLMMemoryService,
+)
+from google.genai import types
+
+MOCK_APP_NAME = "test-app"
+MOCK_USER_ID = "test-user"
+MOCK_SESSION_ID = "session-1"
+
+MOCK_SESSION = Session(
+    app_name=MOCK_APP_NAME,
+    user_id=MOCK_USER_ID,
+    id=MOCK_SESSION_ID,
+    last_update_time=1000,
+    events=[
+        Event(
+            id="event-1",
+            author="user",
+            timestamp=12345,
+            content=types.Content(parts=[types.Part(text="I love hiking.")]),
+        ),
+    ],
+)
+
+
+@pytest.fixture
+def mock_auth():
+    with patch("google.auth.default") as mock_default:
+        mock_default.return_value = (MagicMock(), "test-project")
+        yield mock_default
+
+
+@pytest.fixture
+def mock_firestore():
+    with patch("google.cloud.firestore.AsyncClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_collection = MagicMock()
+        mock_document = MagicMock()
+        mock_subcollection = MagicMock()
+
+        mock_client.collection.return_value = mock_collection
+        mock_collection.document.return_value = mock_document
+        mock_document.collection.return_value = mock_subcollection
+
+        # Batch mock
+        mock_batch = MagicMock()
+        mock_batch.commit = AsyncMock()
+        mock_client.batch.return_value = mock_batch
+
+        yield mock_client
+
+
+@pytest.fixture
+def service(mock_auth, mock_firestore):
+    with patch(
+        "google.adk.agents.llm_agent.Agent.canonical_model",
+        new_callable=MagicMock,
+    ) as mock_model:
+        mock_model.model = "gemini-2.0-flash"
+        service = FirestoreLLMMemoryService(collection_name="test_facts")
+        yield service
+
+
+class TestFirestoreLLMMemoryService:
+    def test_init(self, mock_auth, mock_firestore):
+        service = FirestoreLLMMemoryService(
+            collection_name="custom_facts", model="gemini-2.0-flash"
+        )
+        assert service.collection_name == "custom_facts"
+        assert service._memory_agent.model == "gemini-2.0-flash"
+
+    @pytest.mark.asyncio
+    async def test_add_session_to_memory_success(self, service, mock_firestore):
+        # 1. Mock existing facts in Firestore
+        mock_doc = MagicMock()
+        mock_doc.id = "fact-1"
+        mock_doc.to_dict.return_value = {"text": "Old fact"}
+
+        async def mock_stream():
+            yield mock_doc
+
+        mock_events = (
+            mock_firestore.collection.return_value.document.return_value.collection
+        )
+        mock_events.return_value.stream.return_value = mock_stream()
+
+        # 2. Mock LLM Response
+        llm_response_json = {
+            "add": ["Likes hiking"],
+            "update": [{"id": "fact-1", "text": "Actually hates hiking"}],
+            "delete": [],
+        }
+
+        mock_response = MagicMock()
+        mock_response.partial = False
+        mock_response.content.parts = [types.Part(text=json.dumps(llm_response_json))]
+
+        async def mock_generate(*args, **kwargs):
+            yield mock_response
+
+        service._memory_agent.canonical_model.generate_content_async.side_effect = (
+            mock_generate
+        )
+
+        await service.add_session_to_memory(MOCK_SESSION)
+
+        # 3. Verify Batch Operations
+        mock_batch = mock_firestore.batch.return_value
+        assert mock_batch.set.call_count == 1
+        assert mock_batch.update.call_count == 1
+        assert mock_batch.delete.call_count == 0
+        mock_batch.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_memory_success(self, service, mock_firestore):
+        # 1. Mock stored facts
+        mock_doc = MagicMock()
+        mock_doc.id = "fact-1"
+        mock_doc.to_dict.return_value = {
+            "text": "User likes hiking",
+            "timestamp": MagicMock(timestamp=lambda: 1234567.0),
+            "source_session_id": "session-1",
+        }
+
+        async def mock_stream():
+            yield mock_doc
+
+        mock_events = (
+            mock_firestore.collection.return_value.document.return_value.collection
+        )
+        mock_events.return_value.stream.return_value = mock_stream()
+
+        # 2. Mock LLM Filtering Response
+        mock_response = MagicMock()
+        mock_response.partial = False
+        mock_response.content.parts = [types.Part(text='["fact-1"]')]
+
+        async def mock_generate(*args, **kwargs):
+            yield mock_response
+
+        service._memory_agent.canonical_model.generate_content_async.side_effect = (
+            mock_generate
+        )
+
+        response = await service.search_memory(
+            app_name=MOCK_APP_NAME,
+            user_id=MOCK_USER_ID,
+            query="What does the user like?",
+        )
+
+        assert len(response.memories) == 1
+        assert response.memories[0].content.parts[0].text == "User likes hiking"
+        assert response.memories[0].author == "memory_manager"
+
+    @pytest.mark.asyncio
+    async def test_add_session_malformed_json(self, service, mock_firestore):
+        # Mock LLM returning garbage
+        mock_response = MagicMock()
+        mock_response.partial = False
+        mock_response.content.parts = [types.Part(text="Not JSON")]
+
+        async def mock_generate(*args, **kwargs):
+            yield mock_response
+
+        service._memory_agent.canonical_model.generate_content_async.side_effect = (
+            mock_generate
+        )
+
+        # Should not raise exception
+        await service.add_session_to_memory(MOCK_SESSION)
+
+        mock_batch = mock_firestore.batch.return_value
+        assert mock_batch.commit.call_count == 0

--- a/tests/unittests/memory/test_firestore_llm_memory_service.py
+++ b/tests/unittests/memory/test_firestore_llm_memory_service.py
@@ -63,6 +63,7 @@ def mock_firestore():
         mock_client.collection.return_value = mock_collection
         mock_collection.document.return_value = mock_document
         mock_document.collection.return_value = mock_subcollection
+        mock_subcollection.order_by.return_value = mock_subcollection
         mock_subcollection.limit.return_value = mock_subcollection
 
         # Batch mock
@@ -102,10 +103,10 @@ class TestFirestoreLLMMemoryService:
         async def mock_stream():
             yield mock_doc
 
-        mock_events = (
-            mock_firestore.collection.return_value.document.return_value.collection
+        mock_subcollection = (
+            mock_firestore.collection.return_value.document.return_value.collection.return_value
         )
-        mock_events.return_value.stream.return_value = mock_stream()
+        mock_subcollection.stream.return_value = mock_stream()
 
         # 2. Mock LLM Response
         llm_response_json = {
@@ -148,10 +149,14 @@ class TestFirestoreLLMMemoryService:
         async def mock_stream():
             yield mock_doc
 
-        mock_events = (
-            mock_firestore.collection.return_value.document.return_value.collection
+        # Setup the subcollection mock chain
+        mock_subcollection = MagicMock()
+        mock_firestore.collection.return_value.document.return_value.collection.return_value = (
+            mock_subcollection
         )
-        mock_events.return_value.stream.return_value = mock_stream()
+        mock_subcollection.order_by.return_value = mock_subcollection
+        mock_subcollection.limit.return_value = mock_subcollection
+        mock_subcollection.stream.return_value = mock_stream()
 
         # 2. Mock LLM Filtering Response
         mock_response = MagicMock()

--- a/tests/unittests/memory/test_firestore_word_memory_service.py
+++ b/tests/unittests/memory/test_firestore_word_memory_service.py
@@ -146,7 +146,6 @@ class TestFirestoreWordMemoryService:
     async def test_search_memory_success(self, service, mock_firestore):
         # Setup mock for stream()
         mock_query = MagicMock()
-        mock_docs = MagicMock()
 
         # Create mock document snapshots
         mock_doc1 = MagicMock()

--- a/tests/unittests/memory/test_firestore_word_memory_service.py
+++ b/tests/unittests/memory/test_firestore_word_memory_service.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from google.adk.events.event import Event
+from google.adk.sessions.session import Session
+from google.adk_community.memory.firestore_word_memory_service import (
+    FirestoreWordMemoryService,
+)
+from google.genai import types
+
+MOCK_APP_NAME = "test-app"
+MOCK_USER_ID = "test-user"
+MOCK_SESSION_ID = "session-1"
+
+MOCK_SESSION = Session(
+    app_name=MOCK_APP_NAME,
+    user_id=MOCK_USER_ID,
+    id=MOCK_SESSION_ID,
+    last_update_time=1000,
+    events=[
+        Event(
+            id="event-1",
+            author="user",
+            timestamp=12345,
+            content=types.Content(parts=[types.Part(text="Hello, I like Python.")]),
+        ),
+        Event(
+            id="event-2",
+            author="model",
+            timestamp=12346,
+            content=types.Content(
+                parts=[types.Part(text="Python is a great programming language.")]
+            ),
+        ),
+        # Empty event, should be ignored
+        Event(
+            id="event-3",
+            author="user",
+            timestamp=12347,
+        ),
+    ],
+)
+
+
+@pytest.fixture
+def mock_firestore_class():
+    with patch("google.cloud.firestore.AsyncClient") as mock_client_class:
+        yield mock_client_class
+
+
+@pytest.fixture
+def mock_firestore(mock_firestore_class):
+    mock_client = MagicMock()
+    mock_firestore_class.return_value = mock_client
+
+    # Chainable mocks
+    mock_collection = MagicMock()
+    mock_document = MagicMock()
+    mock_subcollection = MagicMock()
+
+    mock_client.collection.return_value = mock_collection
+    mock_collection.document.return_value = mock_document
+    mock_document.collection.return_value = mock_subcollection
+
+    # Async methods
+    mock_subcollection.add = AsyncMock()
+
+    yield mock_client
+
+
+@pytest.fixture
+def mock_auth():
+    with patch("google.auth.default") as mock_default:
+        mock_default.return_value = (MagicMock(), "test-project")
+        yield mock_default
+
+
+@pytest.fixture
+def service(mock_auth, mock_firestore):
+    return FirestoreWordMemoryService(
+        collection_name="test_memories", database="test-db"
+    )
+
+
+class TestFirestoreWordMemoryService:
+    def test_init(self, mock_auth, mock_firestore_class):
+        service = FirestoreWordMemoryService(
+            collection_name="custom_col", database="custom_db"
+        )
+        assert service.collection_name == "custom_col"
+        mock_firestore_class.assert_called_once()
+        # Check if database was passed to AsyncClient
+        _, kwargs = mock_firestore_class.call_args
+        assert kwargs["database"] == "custom_db"
+        assert kwargs["project"] == "test-project"
+
+    @pytest.mark.asyncio
+    async def test_add_session_to_memory(self, service, mock_firestore):
+        await service.add_session_to_memory(MOCK_SESSION)
+
+        mock_collection = mock_firestore.collection
+        mock_collection.assert_called_with("test_memories")
+
+        user_key = f"{MOCK_APP_NAME}:{MOCK_USER_ID}"
+        mock_collection.return_value.document.assert_called_with(user_key)
+
+        mock_subcollection = (
+            mock_collection.return_value.document.return_value.collection
+        )
+        mock_subcollection.assert_called_with("events")
+
+        # Should be 2 calls for the 2 events with content
+        assert mock_subcollection.return_value.add.call_count == 2
+
+        # Verify first event data
+        call_args = mock_subcollection.return_value.add.call_args_list[0]
+        event_data = call_args.args[0]
+        assert event_data["session_id"] == MOCK_SESSION_ID
+        assert event_data["author"] == "user"
+        assert "python" in event_data["words"]
+        assert "hello" in event_data["words"]
+        assert event_data["content"]["parts"][0]["text"] == "Hello, I like Python."
+
+    @pytest.mark.asyncio
+    async def test_search_memory_empty_query(self, service):
+        response = await service.search_memory(
+            app_name=MOCK_APP_NAME, user_id=MOCK_USER_ID, query=""
+        )
+        assert len(response.memories) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_memory_success(self, service, mock_firestore):
+        # Setup mock for stream()
+        mock_query = MagicMock()
+        mock_docs = MagicMock()
+
+        # Create mock document snapshots
+        mock_doc1 = MagicMock()
+        mock_doc1.to_dict.return_value = {
+            "content": {"parts": [{"text": "Python is fun"}]},
+            "author": "user",
+            "timestamp": 12345,
+        }
+
+        async def mock_stream():
+            yield mock_doc1
+
+        mock_query.stream.return_value = mock_stream()
+
+        # Setup chain for search
+        mock_collection = mock_firestore.collection
+        mock_document = mock_collection.return_value.document
+        mock_events = mock_document.return_value.collection
+        mock_events.return_value.where.return_value = mock_query
+
+        response = await service.search_memory(
+            app_name=MOCK_APP_NAME, user_id=MOCK_USER_ID, query="python"
+        )
+
+        assert len(response.memories) == 1
+        assert response.memories[0].content.parts[0].text == "Python is fun"
+        assert response.memories[0].author == "user"
+
+        # Verify query was constructed correctly
+        mock_events.return_value.where.assert_called_once()
+        _, kwargs = mock_events.return_value.where.call_args
+        filter_obj = kwargs["filter"]
+        # In some versions of firestore, these are private or stored in _to_pb()
+        # For testing, we just check that it's a FieldFilter
+        from google.cloud.firestore_v1.base_query import FieldFilter
+
+        assert isinstance(filter_obj, FieldFilter)

--- a/tests/unittests/memory/test_firestore_word_memory_service.py
+++ b/tests/unittests/memory/test_firestore_word_memory_service.py
@@ -40,7 +40,7 @@ MOCK_SESSION = Session(
         ),
         Event(
             id="event-2",
-            author="model",
+            author="agent",
             timestamp=12346,
             content=types.Content(
                 parts=[types.Part(text="Python is a great programming language.")]

--- a/tests/unittests/memory/test_firestore_word_memory_service.py
+++ b/tests/unittests/memory/test_firestore_word_memory_service.py
@@ -75,6 +75,8 @@ def mock_firestore(mock_firestore_class):
     mock_client.collection.return_value = mock_collection
     mock_collection.document.return_value = mock_document
     mock_document.collection.return_value = mock_subcollection
+    mock_subcollection.where.return_value = mock_subcollection
+    mock_subcollection.limit.return_value = mock_subcollection
 
     # Batch mock
     mock_batch = MagicMock()
@@ -150,6 +152,7 @@ class TestFirestoreWordMemoryService:
     async def test_search_memory_success(self, service, mock_firestore):
         # Setup mock for stream()
         mock_query = MagicMock()
+        mock_query.limit.return_value = mock_query
 
         # Create mock document snapshots
         mock_doc1 = MagicMock()


### PR DESCRIPTION
Adds two firestore memory options for https://github.com/google/adk-python-community/issues/38

Word memory service is a simple work-alike which matches the keyword-based search behavior of InMemoryMemoryService.

LLm memory service uses a LLM to summarize memories from a session, updating, deleting them as the need arises.
