### PR TITLE
Fix: RedisSessionService.list_sessions() state loss bug

### DIFF
--- a/src/google/adk_community/sessions/redis_session_service.py
+++ b/src/google/adk_community/sessions/redis_session_service.py
@@ -175,7 +175,7 @@ class RedisSessionService(BaseSessionService):
         for session_data in sessions.values():
             session = Session.model_validate(session_data)
             session.events = []
-            session.state = {}
+            session = await self._merge_state(app_name, user_id, session)
             sessions_without_events.append(session)
 
         return ListSessionsResponse(sessions=sessions_without_events)


### PR DESCRIPTION
Description

  Fixes a bug in RedisSessionService.list_sessions() where session state was being cleared instead of preserved, causing loss of app-level and user-level state data.

  Problem

  RedisSessionService.list_sessions() was clearing session state by setting session.state = {} at line 178, which caused:
  - Loss of session metadata (like 'title', '_ag_ui_thread_id', custom fields)
  - Inconsistency with InMemorySessionService.list_sessions() which correctly preserves state
  - Frontend applications unable to display session metadata in session lists
  - State only available when fetching individual sessions via get_session()

  Root Cause

  The method was directly clearing state instead of merging app/user state from Redis hashes, breaking the state management contract that other methods (get_session(), create_session()) correctly implement.

  Solution

  Replace session.state = {} with session = await self._merge_state(app_name, user_id, session) to match the behavior of:
  - InMemorySessionService.list_sessions() (line 64-65)
  - RedisSessionService.get_session() (line 166)
  - RedisSessionService.create_session() (line 133)

  Changes

  - File: src/google/adk_community/sessions/redis_session_service.py
  - Line 178: Changed from session.state = {} to session = await self._merge_state(app_name, user_id, session)
  - Ensures consistent state handling across all session operations
  - Maintains backward compatibility (events still cleared as intended)

  Testing

  Verified that:
  - list_sessions() now returns sessions with app/user state preserved
  - Session metadata (title, custom fields) appears in session lists
  - Existing functionality remains unchanged
  - Behavior now consistent with InMemorySessionService
