### PR TITLE
fix: add workflow_dispatch trigger to release-please workflow

### DIFF
--- a/.github/workflows/cherry-pick-to-release.yml
+++ b/.github/workflows/cherry-pick-to-release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   cherry-pick:
@@ -38,4 +39,12 @@ jobs:
         run: |
           git push origin release/v${{ inputs.version }}
           echo "Successfully cherry-picked commit to release/v${{ inputs.version }}"
-          echo "Release-please will update the CHANGELOG PR automatically."
+
+      - name: Trigger Release Please
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release-please.yml \
+            --repo ${{ github.repository }} \
+            -f version=${{ inputs.version }}
+          echo "Triggered Release Please workflow for version ${{ inputs.version }}"

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   cut-branch:
@@ -58,3 +59,12 @@ jobs:
 
           git commit -m "$COMMIT_MSG"
           git push origin "release/v${{ inputs.version }}"
+
+      - name: Trigger Release Please
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release-please.yml \
+            --repo ${{ github.repository }} \
+            -f version=${{ inputs.version }}
+          echo "Triggered Release Please workflow for version ${{ inputs.version }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - 'release/**'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 0.3.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,18 +19,24 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version from branch name
-        id: extract-version
+      - name: Determine version
+        id: version
         run: |
-          # Branch name is like "release/v0.3.0", extract "0.3.0"
-          VERSION="${GITHUB_REF_NAME#release/v}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+            BRANCH="release/v${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#release/v}"
+            BRANCH="${GITHUB_REF_NAME}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Extracted version: $VERSION"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION, Branch: $BRANCH"
 
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-          target-branch: ${{ github.ref_name }}
-          release-as: ${{ steps.extract-version.outputs.version }}
+          target-branch: ${{ steps.version.outputs.branch }}
+          release-as: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
Adds manual trigger (`workflow_dispatch`) to the release-please workflow and auto-triggers it from other workflows.

## Changes
1. **release-please.yml**: Added `workflow_dispatch` trigger with version input
2. **cut-release-branch.yml**: Auto-triggers release-please after pushing
3. **cherry-pick-to-release.yml**: Auto-triggers release-please after cherry-pick

## Why
When workflows push using `GITHUB_TOKEN`, GitHub does not trigger other workflows (security feature). Now all workflows explicitly trigger release-please.

## Updated Release Process

| Step | Action | Trigger |
|------|--------|---------|
| 1 | Cut release branch | Manual workflow |
| 2 | Release Please creates CHANGELOG PR | Auto (triggered by step 1) |
| 3 | Test | Manual |
| 4 | Review + merge CHANGELOG PR | Manual |
| 5 | Draft release created | Auto |
| 6 | Publish release | Manual |
| 7 | Publish to PyPI | Manual workflow |
| 8 | Merge-back PR | Auto → merge manually |

Cherry-picking also auto-triggers release-please to update the CHANGELOG PR.