### PR TITLE
fix: set release-as at runtime instead of committing to config

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -31,34 +31,12 @@ jobs:
             exit 1
           fi
 
-      - name: Create release branch
+      - name: Create and push release branch
         run: |
           BRANCH_NAME="release/v${{ inputs.version }}"
           git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
           echo "Created branch: $BRANCH_NAME"
-
-      - name: Bump version
-        run: |
-          # Update version.py
-          sed -i 's/__version__ = ".*"/__version__ = "${{ inputs.version }}"/' src/google/adk_community/version.py
-
-          # Update release-please manifest
-          echo '{".": "${{ inputs.version }}"}' > .github/.release-please-manifest.json
-
-          echo "Bumped version to ${{ inputs.version }}"
-
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/google/adk_community/version.py .github/.release-please-manifest.json
-          COMMIT_MSG="chore: bump version to ${{ inputs.version }}
-
-          To test this release:
-          uv pip install git+https://github.com/${{ github.repository }}.git@release/v${{ inputs.version }}"
-
-          git commit -m "$COMMIT_MSG"
-          git push origin "release/v${{ inputs.version }}"
 
       - name: Trigger Release Please
         env:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,8 +19,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Determine version
-        id: version
+      - name: Determine version and branch
+        id: vars
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
@@ -33,10 +33,19 @@ jobs:
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
           echo "Version: $VERSION, Branch: $BRANCH"
 
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.vars.outputs.branch }}
+
+      - name: Set release-as version
+        run: |
+          jq --arg version "${{ steps.vars.outputs.version }}" \
+            '.packages["."]["release-as"] = $version' \
+            .github/release-please-config.json > tmp.json && mv tmp.json .github/release-please-config.json
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-          target-branch: ${{ steps.version.outputs.branch }}
-          release-as: ${{ steps.version.outputs.version }}
+          target-branch: ${{ steps.vars.outputs.branch }}


### PR DESCRIPTION
## Summary
- Simplify `cut-release-branch` to just create branch and trigger release-please (no file modifications)
- Move `release-as` configuration to `release-please` workflow at runtime using `jq`
- This avoids polluting main branch when merging back release changes
- Update `publish-pypi` permissions to `contents: write`

## Problem
Previously, `cut-release-branch` committed `release-as` to the config file, which would get merged back to main and require cleanup.

## Solution
Set `release-as` at runtime in `release-please.yml` using `jq` - the change is never committed, so it doesn't pollute any branch.