### PR TITLE
feat: temporarily use PAT token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
           target-branch: ${{ steps.vars.outputs.branch }}


### PR DESCRIPTION
## Summary
- Use `RELEASE_PAT` secret instead of default `GITHUB_TOKEN` for release-please action
- This allows release-please PRs to be authored by a human account

## Setup Required
Add a repository secret named `RELEASE_PAT` with a Personal Access Token that has:
- `repo` scope (or `public_repo` for public repos)
- `workflow` scope