### PR TITLE
fix: skip release-please on changelog PR merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   release-please:
+    # Skip if this is a release-please PR merge (handled by Release: Finalize)
+    if: "!startsWith(github.event.head_commit.message, 'chore(release')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

When the release-please changelog PR is merged to `release/candidate`, it triggers **two** workflows:

1. **Release: Finalize** (via `pull_request: closed`) - Success
2. **Release: Please** (via `push: release/candidate`) - Failure

The second run fails because `Release: Finalize` is already handling the branch (creating `release/v{version}` and deleting `release/candidate`).

## Fix

Skip `Release: Please` when the commit message starts with `chore(release` (the release-please commit prefix):

```yaml
if: "!startsWith(github.event.head_commit.message, 'chore(release')"
```

This ensures:
- Normal pushes (cherry-picks, fixes) → Run release-please
- Changelog PR merge → Skip (handled by Release: Finalize)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)