### PR TITLE
chore: infer version from branch in release-publish workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,11 +4,6 @@ name: "Release: Publish to PyPi"
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g., 0.3.0)'
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -18,9 +13,22 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate branch
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Must run from a release/v* branch (e.g., release/v0.3.0)"
+            exit 1
+          fi
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#release/v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
       - uses: actions/checkout@v4
-        with:
-          ref: release/v${{ inputs.version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -46,6 +54,6 @@ jobs:
         run: |
           gh pr create \
             --base main \
-            --head "release/v${{ inputs.version }}" \
-            --title "chore: merge release v${{ inputs.version }} to main" \
-            --body "Syncs version bump and CHANGELOG from release v${{ inputs.version }} to main."
+            --head "${{ github.ref_name }}" \
+            --title "chore: merge release v${{ steps.version.outputs.version }} to main" \
+            --body "Syncs version bump and CHANGELOG from release v${{ steps.version.outputs.version }} to main."


### PR DESCRIPTION
## Summary
- Remove manual version input from `Release: Publish to PyPi` workflow
- Version is now extracted from the selected release branch (e.g., `release/v0.3.0` → `0.3.0`)
- Added validation to ensure workflow is run from a `release/v*` branch

## Test plan
- [x] Run workflow from `release/v0.3.0` branch - should work
- [x] Run workflow from `main` branch - should fail with error