### PR TITLE
feat: add release tag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,43 @@
+# Tags the version on the main branch commit where the release was cut from.
+# Run this from the release/v* branch after the GitHub release is created.
+# This ensures release-please can correctly identify new commits in the next release.
+name: "Release: Tag"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Must run from a release/v* branch (e.g., release/v0.3.0)"
+            exit 1
+          fi
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#release/}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Tagging version: $VERSION"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Tag version on main cut point
+        run: |
+          git fetch origin main
+          CUT_SHA=$(git merge-base origin/main HEAD)
+          echo "Release was cut from main at: $CUT_SHA"
+          git tag -f "${{ steps.version.outputs.version }}" "$CUT_SHA"
+          git push origin "${{ steps.version.outputs.version }}" --force
+          echo "Tagged ${{ steps.version.outputs.version }} at $CUT_SHA"


### PR DESCRIPTION
## Summary
- Adds a manually-triggered `Release: Tag` workflow that tags `v{version}` on the main branch commit where the release was originally cut from
- Uses `git merge-base` to find the fork point between `release/v*` and `main`
- Ensures release-please can correctly identify new commits in the next release

## Test plan
- [x] After a release is finalized and GitHub release is created, trigger the workflow from the `release/v*` branch
- [x] Verify the `v{version}` tag points to the correct commit on main (the cut point)
- [x] Verify release-please correctly diffs from the new tag in the next release cycle