### PR TITLE
chore: add step numbers to release workflow headers

### DIFF
--- a/.github/workflows/release-cherry-pick.yml
+++ b/.github/workflows/release-cherry-pick.yml
@@ -1,5 +1,5 @@
-# Cherry-picks a commit from main to the release/candidate branch.
-# Use this to include bug fixes in an in-progress release.
+# Step 3 (optional): Cherry-picks a commit from main to the release/candidate branch.
+# Use between step 1 and step 4 to include bug fixes in an in-progress release.
 name: "Release: Cherry-pick"
 
 on:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,5 +1,5 @@
-# Starts the release process by creating a release/candidate branch.
-# Triggers release-please to generate a changelog PR.
+# Step 1: Starts the release process by creating a release/candidate branch.
+# Generates a changelog PR for review (step 2).
 name: "Release: Cut"
 
 on:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,5 +1,5 @@
-# Triggers when release-please PR is merged to release/candidate.
-# Renames release/candidate to release/v{version}.
+# Step 4: Triggers when the changelog PR is merged to release/candidate.
+# Records last-release-sha and renames release/candidate to release/v{version}.
 name: "Release: Finalize"
 
 on:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,5 @@
 # Runs release-please to create/update a PR with version bump and changelog.
-# Triggered by pushes to release/candidate or manually.
+# Triggered automatically by step 1 (cut) or step 3 (cherry-pick).
 name: "Release: Please"
 
 on:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,5 +1,5 @@
-# Builds and publishes the package to PyPI from a release branch.
-# Creates a merge-back PR to sync release changes to main.
+# Step 6: Builds and publishes the package to PyPI from a release/v{version} branch.
+# Creates a merge-back PR (step 7) to sync release changes to main.
 name: "Release: Publish to PyPi"
 
 on:


### PR DESCRIPTION
## Summary
- Add step numbers to release workflow header comments matching the release process checklist

| Step | Action | Workflow |
|---|---|---|
| Step 1 | Cut release candidate | `release-cut.yml` |
| Step 2 | Review changelog PR | Manual |
| Step 3 | Cherry-pick fixes (optional) | `release-cherry-pick.yml` |
| Step 4 | Merge changelog PR | `release-finalize.yml` |
| Step 5 | Create GitHub Release | Manual |
| Step 6 | Publish to PyPI | `release-publish.yml` |
| Step 7 | Merge back to main | Manual (PR created by step 6) |

## Test plan
- Comment-only changes, no behavioral impact