### PR TITLE
fix(release): configure git identity from RELEASE_PAT in finalize

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -44,6 +44,15 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
+      - name: Configure git identity from RELEASE_PAT
+        if: steps.check.outputs.is_release_pr == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          USER_JSON=$(gh api user)
+          git config user.name "$(echo "$USER_JSON" | jq -r '.login')"
+          git config user.email "$(echo "$USER_JSON" | jq -r '.id')+$(echo "$USER_JSON" | jq -r '.login')@users.noreply.github.com"
+
       - name: Record last-release-sha for release-please
         if: steps.check.outputs.is_release_pr == 'true'
         run: |


### PR DESCRIPTION
## Summary
- Fix `Author identity unknown` error in release-finalize workflow
- Derive `user.name` and `user.email` from the `RELEASE_PAT` owner via `gh api user` so the last-release-sha commit passes CLA checks

## Test plan
- [ ] Trigger a test release to verify the finalize workflow completes without the git identity error