### PR TITLE
fix(release): skip release-please when release/candidate is renamed

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,11 +18,25 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'chore(release')"
     runs-on: ubuntu-latest
     steps:
+      - name: Check if release/candidate still exists
+        id: check
+        run: |
+          if git ls-remote --exit-code --heads origin release/candidate &>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "release/candidate branch no longer exists, skipping"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - uses: actions/checkout@v4
+        if: steps.check.outputs.exists == 'true'
         with:
           ref: release/candidate
 
       - uses: googleapis/release-please-action@v4
+        if: steps.check.outputs.exists == 'true'
         with:
           token: ${{ secrets.RELEASE_PAT }}
           config-file: .github/release-please-config.json


### PR DESCRIPTION
## Summary
- Add a branch existence check before running release-please
- When finalize pushes the last-release-sha commit and then renames `release/candidate`, the push triggers `release-please.yml` but the branch no longer exists by the time it runs
- Now gracefully skips instead of failing at checkout

## Test plan
- [x] Verify release-please workflow shows as successful (skipped) rather than failed when release/candidate is renamed