### PR TITLE
fix(release): dispatch release-please on release/candidate branch

### DIFF
--- a/.github/workflows/release-cherry-pick.yml
+++ b/.github/workflows/release-cherry-pick.yml
@@ -42,5 +42,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run release-please.yml --repo ${{ github.repository }}
+          gh workflow run release-please.yml --repo ${{ github.repository }} --ref release/candidate
           echo "Triggered Release Please workflow"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -42,5 +42,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run release-please.yml --repo ${{ github.repository }}
+          gh workflow run release-please.yml --repo ${{ github.repository }} --ref release/candidate
           echo "Triggered Release Please workflow"


### PR DESCRIPTION
## Summary
- Add `--ref release/candidate` to `gh workflow run` in release-cut and release-cherry-pick
- Without this, `workflow_dispatch` defaults to main, so release-please runs on the wrong branch and skips (since the branch check added in #83 correctly detects it's not on `release/candidate`)

Root cause: pushes with `GITHUB_TOKEN` don't trigger other workflows (GitHub's design), so the `push` trigger in `release-please.yml` never fires — the explicit `gh workflow run` dispatch is the only trigger, and it was missing `--ref`.

## Test plan
- [x] Run release-cut and verify release-please creates a changelog PR on `release/candidate`