### PR TITLE
fix(release): use gh api for branch check in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,15 +20,15 @@ jobs:
     steps:
       - name: Check if release/candidate still exists
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if git ls-remote --exit-code --heads origin release/candidate &>/dev/null; then
+          if gh api repos/${{ github.repository }}/branches/release/candidate --silent 2>/dev/null; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "release/candidate branch no longer exists, skipping"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - uses: actions/checkout@v4
         if: steps.check.outputs.exists == 'true'


### PR DESCRIPTION
## Summary
- Replace `git ls-remote` with `gh api` for the branch existence check in release-please workflow
- `git ls-remote origin` fails before `actions/checkout` since no git repo exists on the runner, causing the check to always report the branch as missing

## Test plan
- [x] Delete `release/candidate`, trigger release-please manually, verify it skips gracefully
- [x] With `release/candidate` present, trigger release-please, verify it creates a changelog PR