### PR TITLE
feat(governance): add SidClaw governance service integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "google-adk", # Google ADK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
   "redis>=5.0.0, <6.0.0", # Redis for session storage
+  "sidclaw>=0.1.2", # SidClaw governance service
   # go/keep-sorted end
   "orjson>=3.11.3",
 ]

--- a/src/google/adk_community/governance/__init__.py
+++ b/src/google/adk_community/governance/__init__.py
@@ -1,0 +1,34 @@
+# Copyright 2026 SidClaw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""SidClaw governance integration for Google ADK agents.
+
+Provides policy evaluation, human-in-the-loop approval, and
+tamper-proof audit trails for ADK agent tool calls via the
+SidClaw platform.
+
+Usage::
+
+    from google.adk_community.governance import (
+        SidClawGovernanceService,
+    )
+"""
+
+from .sidclaw_governance import SidClawGovernanceConfig
+from .sidclaw_governance import SidClawGovernanceService
+
+__all__ = [
+    "SidClawGovernanceConfig",
+    "SidClawGovernanceService",
+]

--- a/src/google/adk_community/governance/sidclaw_governance.py
+++ b/src/google/adk_community/governance/sidclaw_governance.py
@@ -1,0 +1,363 @@
+# Copyright 2026 SidClaw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""SidClaw governance service for Google ADK agents.
+
+Provides policy evaluation, human-in-the-loop approval, and
+tamper-proof audit trails for ADK agent tool calls via the
+SidClaw platform (https://sidclaw.com).
+
+Usage::
+
+    from sidclaw import AsyncSidClaw
+    from google.adk_community.governance import (
+        SidClawGovernanceConfig,
+        SidClawGovernanceService,
+    )
+    from google.adk.agents import Agent
+
+    client = AsyncSidClaw(
+        api_key="ai_...",
+        base_url="https://api.sidclaw.com",
+        agent_id="my-adk-agent",
+    )
+    governance = SidClawGovernanceService(client=client)
+
+    agent = Agent(
+        name="my-agent",
+        model="gemini-2.5-flash",
+        instruction="You are a helpful assistant.",
+        tools=[search_docs, query_database],
+        before_tool_callback=governance.before_tool_callback,
+        after_tool_callback=governance.after_tool_callback,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+
+logger = logging.getLogger("google_adk." + __name__)
+
+# SidClaw SDK imports are deferred to __init__ of the service
+# to give a clear error if the package is not installed.
+_SIDCLAW_IMPORT_ERROR: Optional[ImportError] = None
+try:
+  from sidclaw import AsyncSidClaw
+except ImportError as e:
+  _SIDCLAW_IMPORT_ERROR = e
+  AsyncSidClaw = None  # type: ignore[assignment,misc]
+
+
+class SidClawGovernanceConfig(BaseModel):
+  """Configuration for SidClaw governance callbacks.
+
+  Attributes:
+    default_classification: Default data classification for tool
+      calls when no per-tool override is set. One of ``public``,
+      ``internal``, ``confidential``, ``restricted``.
+    tool_classifications: Per-tool data classification overrides
+      keyed by tool name.
+    resource_scope: Resource scope sent to the SidClaw policy
+      engine.
+    wait_for_approval: If ``True``, the before-tool callback
+      blocks until a human reviewer approves or denies the
+      request.  If ``False``, tool calls requiring approval
+      are rejected immediately.
+    approval_timeout_seconds: Maximum seconds to wait for an
+      approval decision when ``wait_for_approval`` is enabled.
+    approval_poll_interval_seconds: Polling interval in seconds
+      when waiting for an approval decision.
+    state_key: Key used to store the SidClaw trace ID in
+      ``tool_context.state`` between before/after callbacks.
+  """
+
+  default_classification: str = "internal"
+  tool_classifications: Dict[str, str] = Field(default_factory=dict)
+  resource_scope: str = "google_adk"
+  wait_for_approval: bool = True
+  fail_open: bool = False
+  approval_timeout_seconds: float = 300.0
+  approval_poll_interval_seconds: float = 2.0
+  state_key: str = "_sidclaw_trace_id"
+
+
+class SidClawGovernanceService:
+  """Governance service that provides ADK agent tool callbacks.
+
+  Creates ``before_tool_callback`` and ``after_tool_callback``
+  functions that integrate with ADK's agent lifecycle.  The
+  before-callback evaluates each tool call against SidClaw
+  policies; the after-callback records the execution outcome
+  for the audit trail.
+
+  Example::
+
+      governance = SidClawGovernanceService(client=my_client)
+
+      agent = Agent(
+          name="governed-agent",
+          model="gemini-2.5-flash",
+          before_tool_callback=governance.before_tool_callback,
+          after_tool_callback=governance.after_tool_callback,
+          tools=[my_tool],
+      )
+  """
+
+  def __init__(
+      self,
+      client: "AsyncSidClaw",
+      config: Optional[SidClawGovernanceConfig] = None,
+  ) -> None:
+    """Initialise the governance service.
+
+    Args:
+      client: An ``AsyncSidClaw`` instance configured with an
+        API key and agent ID.
+      config: Optional governance configuration.  Uses sensible
+        defaults if not provided.
+
+    Raises:
+      ImportError: If the ``sidclaw`` package is not installed.
+    """
+    if _SIDCLAW_IMPORT_ERROR is not None:
+      raise ImportError(
+          "The sidclaw package is required for SidClaw "
+          "governance. Install it with: pip install sidclaw"
+      ) from _SIDCLAW_IMPORT_ERROR
+
+    self._client = client
+    self._config = config or SidClawGovernanceConfig()
+
+  # ------------------------------------------------------------------
+  # Before-tool callback
+  # ------------------------------------------------------------------
+
+  async def before_tool_callback(
+      self,
+      tool: Any,
+      args: Dict[str, Any],
+      tool_context: Any,
+  ) -> Optional[Dict[str, Any]]:
+    """Evaluate tool call against SidClaw policies.
+
+    This callback is invoked by ADK before every tool
+    execution.  It sends the tool name and arguments to the
+    SidClaw policy engine and handles the decision:
+
+    - **allow**: returns ``None`` so the tool executes.
+    - **deny**: returns an error dict, blocking execution.
+    - **approval_required**: waits for human approval (if
+      configured) or returns an error dict.
+
+    Args:
+      tool: The ADK tool about to be invoked.
+      args: Arguments that will be passed to the tool.
+      tool_context: ADK tool context with state and session.
+
+    Returns:
+      ``None`` to proceed with tool execution, or a ``dict``
+      with an ``error`` key to short-circuit.
+    """
+    tool_name = getattr(tool, "name", "unknown_tool")
+    classification = self._config.tool_classifications.get(
+        tool_name, self._config.default_classification
+    )
+
+    try:
+      decision = await self._client.evaluate({
+          "operation": tool_name,
+          "target_integration": "google_adk",
+          "resource_scope": self._config.resource_scope,
+          "data_classification": classification,
+          "context": {
+              "tool_name": tool_name,
+              "args": _safe_serialize(args),
+          },
+      })
+    except Exception:
+      logger.exception(
+          "SidClaw policy evaluation failed for tool %s",
+          tool_name,
+      )
+      if self._config.fail_open:
+        return None
+      return {
+          "error": (
+              "Governance evaluation failed — tool blocked. "
+              "Set fail_open=True to allow tools when SidClaw "
+              "is unreachable."
+          ),
+      }
+
+    # Store trace ID for the after-tool callback.
+    tool_context.state[self._config.state_key] = (
+        decision.trace_id
+    )
+
+    if decision.decision == "allow":
+      logger.debug(
+          "Tool %s allowed by policy (trace=%s)",
+          tool_name,
+          decision.trace_id,
+      )
+      return None
+
+    if decision.decision == "deny":
+      logger.info(
+          "Tool %s denied by policy: %s (trace=%s)",
+          tool_name,
+          decision.reason,
+          decision.trace_id,
+      )
+      return {"error": f"Policy denied: {decision.reason}"}
+
+    # approval_required
+    if (
+        not self._config.wait_for_approval
+        or not decision.approval_request_id
+    ):
+      logger.info(
+          "Tool %s requires approval (not waiting): %s",
+          tool_name,
+          decision.reason,
+      )
+      return {
+          "error": (
+              f"Approval required: {decision.reason}. "
+              f"Approval ID: {decision.approval_request_id}"
+          ),
+      }
+
+    # Wait for human approval.
+    logger.info(
+        "Tool %s waiting for approval (id=%s)",
+        tool_name,
+        decision.approval_request_id,
+    )
+    try:
+      status = await self._client.wait_for_approval(
+          decision.approval_request_id,
+          options={
+              "timeout": self._config.approval_timeout_seconds,
+              "poll_interval": (
+                  self._config.approval_poll_interval_seconds
+              ),
+          },
+      )
+    except Exception:
+      logger.exception(
+          "Approval wait failed for tool %s", tool_name
+      )
+      return {
+          "error": (
+              "Approval wait timed out or failed. "
+              f"Approval ID: {decision.approval_request_id}"
+          ),
+      }
+
+    if status.status == "approved":
+      logger.info(
+          "Tool %s approved by %s",
+          tool_name,
+          status.approver_name,
+      )
+      return None
+
+    note = (
+        f": {status.decision_note}" if status.decision_note
+        else ""
+    )
+    logger.info(
+        "Tool %s approval %s%s",
+        tool_name,
+        status.status,
+        note,
+    )
+    return {"error": f"Approval {status.status}{note}"}
+
+  # ------------------------------------------------------------------
+  # After-tool callback
+  # ------------------------------------------------------------------
+
+  async def after_tool_callback(
+      self,
+      tool: Any,
+      args: Dict[str, Any],
+      tool_context: Any,
+      tool_response: Any,
+  ) -> None:
+    """Record tool execution outcome in SidClaw audit trail.
+
+    This callback is invoked by ADK after every successful
+    tool execution.  It records the outcome so the trace is
+    finalized with a ``success`` or ``error`` status.
+
+    Args:
+      tool: The ADK tool that was invoked.
+      args: Arguments that were passed to the tool.
+      tool_context: ADK tool context with state and session.
+      tool_response: The value returned by the tool.
+
+    Returns:
+      ``None`` — the original tool response is used.
+    """
+    trace_id = tool_context.state.get(self._config.state_key)
+    if not trace_id:
+      return None
+
+    tool_name = getattr(tool, "name", "unknown_tool")
+    is_error = (
+        isinstance(tool_response, dict)
+        and "error" in tool_response
+    )
+
+    try:
+      await self._client.record_outcome(
+          trace_id,
+          {
+              "status": "error" if is_error else "success",
+              "metadata": {
+                  "tool_name": tool_name,
+              },
+          },
+      )
+      logger.debug(
+          "Recorded outcome for tool %s (trace=%s)",
+          tool_name,
+          trace_id,
+      )
+    except Exception:
+      logger.exception(
+          "Failed to record outcome for tool %s (trace=%s)",
+          tool_name,
+          trace_id,
+      )
+
+    return None
+
+
+def _safe_serialize(obj: Any) -> Any:
+  """Convert args to a JSON-safe dict for the SidClaw context."""
+  if isinstance(obj, dict):
+    return {
+        k: str(v) if not isinstance(v, (str, int, float, bool))
+        else v
+        for k, v in obj.items()
+    }
+  return {"raw": str(obj)}

--- a/tests/unittests/governance/__init__.py
+++ b/tests/unittests/governance/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 SidClaw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/tests/unittests/governance/test_sidclaw_governance.py
+++ b/tests/unittests/governance/test_sidclaw_governance.py
@@ -1,0 +1,493 @@
+# Copyright 2026 SidClaw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Unit tests for SidClaw governance service."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from google.adk_community.governance.sidclaw_governance import (
+    SidClawGovernanceConfig,
+    SidClawGovernanceService,
+    _safe_serialize,
+)
+
+
+# -------------------------------------------------------------------
+# Fixtures & helpers
+# -------------------------------------------------------------------
+
+
+class FakeDecision:
+  """Minimal stand-in for sidclaw.EvaluateResponse."""
+
+  def __init__(
+      self,
+      decision: str = "allow",
+      trace_id: str = "trc_test123",
+      reason: str = "allowed by policy",
+      approval_request_id: Optional[str] = None,
+      policy_rule_id: Optional[str] = None,
+  ):
+    self.decision = decision
+    self.trace_id = trace_id
+    self.reason = reason
+    self.approval_request_id = approval_request_id
+    self.policy_rule_id = policy_rule_id
+
+
+class FakeApprovalStatus:
+  """Minimal stand-in for sidclaw.ApprovalStatusResponse."""
+
+  def __init__(
+      self,
+      status: str = "approved",
+      approver_name: Optional[str] = "reviewer",
+      decision_note: Optional[str] = None,
+  ):
+    self.status = status
+    self.approver_name = approver_name
+    self.decision_note = decision_note
+
+
+def _make_tool(name: str = "search_docs") -> MagicMock:
+  tool = MagicMock()
+  tool.name = name
+  return tool
+
+
+def _make_tool_context() -> MagicMock:
+  ctx = MagicMock()
+  ctx.state = {}
+  return ctx
+
+
+def _make_client(
+    decision: FakeDecision | None = None,
+    approval_status: FakeApprovalStatus | None = None,
+) -> AsyncMock:
+  client = AsyncMock()
+  client.evaluate = AsyncMock(
+      return_value=decision or FakeDecision()
+  )
+  client.wait_for_approval = AsyncMock(
+      return_value=approval_status or FakeApprovalStatus()
+  )
+  client.record_outcome = AsyncMock(return_value=None)
+  return client
+
+
+# -------------------------------------------------------------------
+# Tests: SidClawGovernanceConfig
+# -------------------------------------------------------------------
+
+
+class TestGovernanceConfig:
+  """Tests for SidClawGovernanceConfig defaults."""
+
+  def test_default_values(self):
+    config = SidClawGovernanceConfig()
+    assert config.default_classification == "internal"
+    assert config.resource_scope == "google_adk"
+    assert config.wait_for_approval is True
+    assert config.approval_timeout_seconds == 300.0
+    assert config.state_key == "_sidclaw_trace_id"
+
+  def test_custom_values(self):
+    config = SidClawGovernanceConfig(
+        default_classification="confidential",
+        tool_classifications={"delete_db": "restricted"},
+        resource_scope="prod",
+        wait_for_approval=False,
+    )
+    assert config.default_classification == "confidential"
+    assert config.tool_classifications["delete_db"] == "restricted"
+    assert config.resource_scope == "prod"
+    assert config.wait_for_approval is False
+
+
+# -------------------------------------------------------------------
+# Tests: before_tool_callback — allow
+# -------------------------------------------------------------------
+
+
+class TestBeforeToolAllow:
+  """Tests for the before-tool callback when policy allows."""
+
+  @pytest.mark.asyncio
+  async def test_allow_returns_none(self):
+    """Allowed tool calls return None (proceed)."""
+    client = _make_client(FakeDecision(decision="allow"))
+    svc = SidClawGovernanceService(client=client)
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {"query": "test"}, _make_tool_context()
+    )
+
+    assert result is None
+
+  @pytest.mark.asyncio
+  async def test_allow_stores_trace_id(self):
+    """Trace ID is stored in tool_context.state."""
+    client = _make_client(
+        FakeDecision(decision="allow", trace_id="trc_abc")
+    )
+    svc = SidClawGovernanceService(client=client)
+    ctx = _make_tool_context()
+
+    await svc.before_tool_callback(
+        _make_tool(), {}, ctx
+    )
+
+    assert ctx.state["_sidclaw_trace_id"] == "trc_abc"
+
+  @pytest.mark.asyncio
+  async def test_allow_calls_evaluate_with_correct_params(self):
+    """Evaluate is called with tool name and classification."""
+    client = _make_client(FakeDecision(decision="allow"))
+    config = SidClawGovernanceConfig(
+        default_classification="confidential",
+        resource_scope="prod",
+    )
+    svc = SidClawGovernanceService(
+        client=client, config=config
+    )
+
+    await svc.before_tool_callback(
+        _make_tool("my_tool"), {"key": "val"}, _make_tool_context()
+    )
+
+    call_args = client.evaluate.call_args[0][0]
+    assert call_args["operation"] == "my_tool"
+    assert call_args["target_integration"] == "google_adk"
+    assert call_args["resource_scope"] == "prod"
+    assert call_args["data_classification"] == "confidential"
+
+  @pytest.mark.asyncio
+  async def test_per_tool_classification_override(self):
+    """Per-tool classification overrides the default."""
+    client = _make_client(FakeDecision(decision="allow"))
+    config = SidClawGovernanceConfig(
+        default_classification="internal",
+        tool_classifications={"send_email": "restricted"},
+    )
+    svc = SidClawGovernanceService(
+        client=client, config=config
+    )
+
+    await svc.before_tool_callback(
+        _make_tool("send_email"), {}, _make_tool_context()
+    )
+
+    call_args = client.evaluate.call_args[0][0]
+    assert call_args["data_classification"] == "restricted"
+
+
+# -------------------------------------------------------------------
+# Tests: before_tool_callback — deny
+# -------------------------------------------------------------------
+
+
+class TestBeforeToolDeny:
+  """Tests for the before-tool callback when policy denies."""
+
+  @pytest.mark.asyncio
+  async def test_deny_returns_error(self):
+    """Denied tool calls return an error dict."""
+    client = _make_client(
+        FakeDecision(
+            decision="deny",
+            reason="destructive operation blocked",
+        )
+    )
+    svc = SidClawGovernanceService(client=client)
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is not None
+    assert "error" in result
+    assert "destructive operation blocked" in result["error"]
+
+
+# -------------------------------------------------------------------
+# Tests: before_tool_callback — approval_required
+# -------------------------------------------------------------------
+
+
+class TestBeforeToolApproval:
+  """Tests for the before-tool callback with approval flow."""
+
+  @pytest.mark.asyncio
+  async def test_approval_wait_approved(self):
+    """Approved requests return None (proceed)."""
+    client = _make_client(
+        decision=FakeDecision(
+            decision="approval_required",
+            approval_request_id="apr_123",
+            reason="needs review",
+        ),
+        approval_status=FakeApprovalStatus(status="approved"),
+    )
+    svc = SidClawGovernanceService(client=client)
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is None
+    client.wait_for_approval.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_approval_wait_denied(self):
+    """Denied approval returns error dict."""
+    client = _make_client(
+        decision=FakeDecision(
+            decision="approval_required",
+            approval_request_id="apr_456",
+            reason="risky operation",
+        ),
+        approval_status=FakeApprovalStatus(
+            status="denied",
+            decision_note="too risky",
+        ),
+    )
+    svc = SidClawGovernanceService(client=client)
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is not None
+    assert "denied" in result["error"].lower()
+    assert "too risky" in result["error"]
+
+  @pytest.mark.asyncio
+  async def test_approval_no_wait_returns_error(self):
+    """When wait_for_approval=False, returns error immediately."""
+    client = _make_client(
+        FakeDecision(
+            decision="approval_required",
+            approval_request_id="apr_789",
+            reason="needs human review",
+        )
+    )
+    config = SidClawGovernanceConfig(wait_for_approval=False)
+    svc = SidClawGovernanceService(
+        client=client, config=config
+    )
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is not None
+    assert "apr_789" in result["error"]
+    client.wait_for_approval.assert_not_awaited()
+
+
+# -------------------------------------------------------------------
+# Tests: before_tool_callback — error handling
+# -------------------------------------------------------------------
+
+
+class TestBeforeToolErrors:
+  """Tests for error handling in before-tool callback."""
+
+  @pytest.mark.asyncio
+  async def test_evaluate_failure_fails_closed_by_default(self):
+    """By default, tool is blocked when SidClaw is unreachable."""
+    client = _make_client()
+    client.evaluate = AsyncMock(
+        side_effect=Exception("connection refused")
+    )
+    svc = SidClawGovernanceService(client=client)
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is not None
+    assert "error" in result
+
+  @pytest.mark.asyncio
+  async def test_evaluate_failure_fails_open_when_configured(self):
+    """With fail_open=True, tool proceeds on SidClaw failure."""
+    client = _make_client()
+    client.evaluate = AsyncMock(
+        side_effect=Exception("connection refused")
+    )
+    config = SidClawGovernanceConfig(fail_open=True)
+    svc = SidClawGovernanceService(
+        client=client, config=config
+    )
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is None  # Fail-open
+
+  @pytest.mark.asyncio
+  async def test_approval_request_id_none_returns_error(self):
+    """approval_required with no ID returns error immediately."""
+    client = _make_client(
+        FakeDecision(
+            decision="approval_required",
+            approval_request_id=None,
+            reason="flagged",
+        )
+    )
+    svc = SidClawGovernanceService(client=client)
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is not None
+    assert "Approval required" in result["error"]
+    client.wait_for_approval.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  async def test_tool_without_name_uses_fallback(self):
+    """Tool with no name attribute uses 'unknown_tool'."""
+    client = _make_client(FakeDecision(decision="allow"))
+    svc = SidClawGovernanceService(client=client)
+    tool = MagicMock(spec=[])  # No name attribute
+
+    await svc.before_tool_callback(tool, {}, _make_tool_context())
+
+    call_args = client.evaluate.call_args[0][0]
+    assert call_args["operation"] == "unknown_tool"
+
+  @pytest.mark.asyncio
+  async def test_wait_for_approval_exception_returns_error(self):
+    """Exception during approval wait returns error dict."""
+    client = _make_client(
+        FakeDecision(
+            decision="approval_required",
+            approval_request_id="apr_exc",
+            reason="needs review",
+        )
+    )
+    client.wait_for_approval = AsyncMock(
+        side_effect=Exception("timeout")
+    )
+    svc = SidClawGovernanceService(client=client)
+
+    result = await svc.before_tool_callback(
+        _make_tool(), {}, _make_tool_context()
+    )
+
+    assert result is not None
+    assert "apr_exc" in result["error"]
+
+
+# -------------------------------------------------------------------
+# Tests: after_tool_callback
+# -------------------------------------------------------------------
+
+
+class TestAfterToolCallback:
+  """Tests for the after-tool callback."""
+
+  @pytest.mark.asyncio
+  async def test_records_success_outcome(self):
+    """Records success when tool returns normally."""
+    client = _make_client()
+    svc = SidClawGovernanceService(client=client)
+    ctx = _make_tool_context()
+    ctx.state["_sidclaw_trace_id"] = "trc_xyz"
+
+    await svc.after_tool_callback(
+        _make_tool(), {}, ctx, {"result": "ok"}
+    )
+
+    client.record_outcome.assert_awaited_once()
+    call_args = client.record_outcome.call_args[0]
+    assert call_args[0] == "trc_xyz"
+    assert call_args[1]["status"] == "success"
+
+  @pytest.mark.asyncio
+  async def test_records_error_outcome(self):
+    """Records error when tool returns error dict."""
+    client = _make_client()
+    svc = SidClawGovernanceService(client=client)
+    ctx = _make_tool_context()
+    ctx.state["_sidclaw_trace_id"] = "trc_err"
+
+    await svc.after_tool_callback(
+        _make_tool(),
+        {},
+        ctx,
+        {"error": "something failed"},
+    )
+
+    call_args = client.record_outcome.call_args[0]
+    assert call_args[1]["status"] == "error"
+
+  @pytest.mark.asyncio
+  async def test_no_trace_id_is_noop(self):
+    """Does nothing when no trace ID is in state."""
+    client = _make_client()
+    svc = SidClawGovernanceService(client=client)
+    ctx = _make_tool_context()
+
+    await svc.after_tool_callback(
+        _make_tool(), {}, ctx, "result"
+    )
+
+    client.record_outcome.assert_not_awaited()
+
+  @pytest.mark.asyncio
+  async def test_record_failure_does_not_raise(self):
+    """Recording failure is logged but does not propagate."""
+    client = _make_client()
+    client.record_outcome = AsyncMock(
+        side_effect=Exception("network error")
+    )
+    svc = SidClawGovernanceService(client=client)
+    ctx = _make_tool_context()
+    ctx.state["_sidclaw_trace_id"] = "trc_fail"
+
+    # Should not raise.
+    await svc.after_tool_callback(
+        _make_tool(), {}, ctx, "result"
+    )
+
+
+# -------------------------------------------------------------------
+# Tests: _safe_serialize
+# -------------------------------------------------------------------
+
+
+class TestSafeSerialize:
+  """Tests for the argument serialiser."""
+
+  def test_dict_passthrough(self):
+    result = _safe_serialize({"key": "val", "n": 42})
+    assert result == {"key": "val", "n": 42}
+
+  def test_complex_values_stringified(self):
+    result = _safe_serialize({"obj": object()})
+    assert isinstance(result["obj"], str)
+
+  def test_non_dict_wrapped(self):
+    result = _safe_serialize("raw string")
+    assert result == {"raw": "raw string"}


### PR DESCRIPTION
## Summary

Add a governance service for Google ADK agents using [SidClaw](https://sidclaw.com) — policy evaluation, human-in-the-loop approval, and tamper-proof audit trails for tool calls.

Closes #113

## Background

This submission was invited by @rohityan in [google/adk-python#5081](https://github.com/google/adk-python/pull/5081):

> "Hi @VladUZH, Closing this PR here as it belongs to adk-python-community repo. We highly recommend releasing the feature as a standalone package that we will then share through: https://google.github.io/adk-docs/integrations/"

**CLA:** Already signed for google/adk-python#5081.

## What It Does

The `SidClawGovernanceService` integrates with ADK's `before_tool_callback` and `after_tool_callback` hooks:

```python
from sidclaw import AsyncSidClaw
from google.adk_community.governance import SidClawGovernanceService

client = AsyncSidClaw(api_key="ai_...", agent_id="my-agent")
governance = SidClawGovernanceService(client=client)

agent = Agent(
    name="governed-agent",
    model="gemini-2.5-flash",
    tools=[search_docs, query_database],
    before_tool_callback=governance.before_tool_callback,
    after_tool_callback=governance.after_tool_callback,
)
```

**Before tool execution:**
- Evaluates the action against SidClaw policies
- **Allow** → tool proceeds (~50ms overhead)
- **Deny** → returns error dict, blocking execution
- **Approval required** → waits for human reviewer via dashboard, Slack, Teams, or Telegram

**After tool execution:**
- Records the outcome in SidClaw's hash-chain audit trail

## Files Changed

| File | Description |
|------|-------------|
| `src/google/adk_community/governance/__init__.py` | Package exports |
| `src/google/adk_community/governance/sidclaw_governance.py` | Governance service (~300 LOC) |
| `tests/unittests/governance/__init__.py` | Test package |
| `tests/unittests/governance/test_sidclaw_governance.py` | 20 unit tests |
| `pyproject.toml` | Added `sidclaw>=0.1.2` dependency |

## Configuration

| Field | Default | Description |
|-------|---------|-------------|
| `default_classification` | `"internal"` | Default data classification for all tools |
| `tool_classifications` | `{}` | Per-tool overrides (e.g., `{"delete_db": "restricted"}`) |
| `resource_scope` | `"google_adk"` | Resource scope for policy matching |
| `wait_for_approval` | `True` | Wait for human approval or reject immediately |
| `fail_open` | `False` | Block tools when SidClaw is unreachable (fail-closed by default) |

## Testing Plan

### Unit Tests

All 20 unit tests pass:

```
pytest tests/unittests/governance/test_sidclaw_governance.py -v
```

Coverage includes:
- ✅ Config defaults and custom values
- ✅ Allow decision path (returns None, stores trace ID)
- ✅ Deny decision path (returns error dict)
- ✅ Approval workflow: wait + approved, wait + denied, no-wait mode
- ✅ Per-tool data classification overrides
- ✅ Fail-closed by default, fail-open when configured
- ✅ Null approval_request_id handling
- ✅ Tool with no name attribute (fallback to "unknown_tool")
- ✅ Exception during wait_for_approval
- ✅ After-tool callback: success/error outcome recording
- ✅ No trace ID → no-op in after callback
- ✅ record_outcome failure does not propagate
- ✅ Argument serialization for complex types

### Manual E2E Testing

Verified with SidClaw platform (https://api.sidclaw.com):
- Tool allowed by policy → executes normally
- Tool denied by policy → returns error, blocks execution
- Tool requiring approval → waits for human decision via Slack
- Audit trail recorded with correct trace IDs and outcomes

## Links

- [SidClaw Documentation](https://docs.sidclaw.com)
- [SidClaw Python SDK on PyPI](https://pypi.org/project/sidclaw/) (Apache 2.0)
- [Google ADK Integration Guide](https://docs.sidclaw.com/docs/integrations/google-adk)