### PR TITLE
chore: drop google-genai from requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [ # List of https://pypi.org/classifiers/
 dependencies = [
   # go/keep-sorted start
   "google-adk", # Google ADK
-  "google-genai>=1.21.1, <2.0.0", # Google GenAI SDK
   "httpx>=0.27.0, <1.0.0", # For OpenMemory service
   "orjson>=3.11.3",
   "redis>=5.0.0, <6.0.0", # Redis for session storage


### PR DESCRIPTION
`adk-python` includes `google-genai` in its dependency list