### PR TITLE
feat(tools): Add GoogleManagedMcpToolset for simplified Google MCP auth

### DIFF
--- a/contributing/samples/bigquery_mcp/__init__.py
+++ b/contributing/samples/bigquery_mcp/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent

--- a/contributing/samples/bigquery_mcp/agent.py
+++ b/contributing/samples/bigquery_mcp/agent.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk_community.tools.google_managed_mcp import (
+    GoogleManagedMcpToolset,
+)
+
+BIGQUERY_AGENT_NAME = "adk_sample_bigquery_mcp_agent"
+
+# GoogleManagedMcpToolset handles auth (ADC with auto-refresh) and
+# endpoint URL resolution automatically.
+bigquery_mcp_toolset = GoogleManagedMcpToolset(product="bigquery")
+
+# The variable name `root_agent` determines what your root agent is for the
+# debug CLI
+root_agent = LlmAgent(
+    model="gemini-2.5-flash",
+    name=BIGQUERY_AGENT_NAME,
+    description=(
+        "Agent to answer questions about BigQuery data and models and execute"
+        " SQL queries using MCP."
+    ),
+    instruction="""\
+        You are a data science agent with access to several BigQuery tools provided via MCP.
+        Make use of those tools to answer the user's questions.
+    """,
+    tools=[bigquery_mcp_toolset],
+)

--- a/contributing/tools/google_managed_mcp/README.md
+++ b/contributing/tools/google_managed_mcp/README.md
@@ -1,0 +1,55 @@
+# GoogleManagedMcpToolset
+
+A `McpToolset` subclass that simplifies connecting to Google-managed MCP servers
+by automating Application Default Credentials (ADC) authentication and endpoint
+URL resolution.
+
+## Features
+
+- **Automatic endpoint resolution**: Just specify the product name (e.g.,
+  `"bigquery"`) and the correct MCP server URL is resolved automatically.
+- **ADC-based authentication**: Uses Application Default Credentials with
+  automatic OAuth2 token refresh — no manual token management required.
+- **Custom scopes & project ID**: Supports optional OAuth2 scope overrides and
+  project ID for quota attribution.
+- **Full McpToolset compatibility**: All standard `McpToolset` parameters
+  (`tool_filter`, `tool_name_prefix`, etc.) are supported.
+
+## Supported Products
+
+| Product    | Endpoint URL                              |
+|------------|-------------------------------------------|
+| `bigquery` | `https://bigquery.googleapis.com/mcp`     |
+
+## Installation
+
+```bash
+pip install google-adk-community[google-managed-mcp]
+```
+
+## Usage
+
+```python
+from google.adk.agents import Agent
+from google.adk_community.tools.google_managed_mcp import (
+    GoogleManagedMcpToolset,
+)
+
+# Minimal — uses ADC and default BigQuery scopes
+toolset = GoogleManagedMcpToolset(product="bigquery")
+
+# With custom project and scopes
+toolset = GoogleManagedMcpToolset(
+    product="bigquery",
+    project_id="my-project",
+    scopes=["https://www.googleapis.com/auth/bigquery.readonly"],
+    tool_filter=["list_datasets", "execute_sql"],
+)
+
+agent = Agent(
+    model="gemini-2.5-flash",
+    name="bq_agent",
+    instruction="Help users query BigQuery.",
+    tools=[toolset],
+)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ sdc-agents = [
     "sdc-agents>=4.3.3; python_version >= '3.11'",
 ]
 spraay = ["web3>=6.0.0"]
+google-managed-mcp = [
+    "google-auth>=2.0.0",  # For ADC-based auth in GoogleManagedMcpToolset
+    "mcp>=1.24,<2",  # MCP protocol support (optional in google-adk)
+]
 
 
 [tool.pyink]

--- a/src/google/adk_community/tools/google_managed_mcp/__init__.py
+++ b/src/google/adk_community/tools/google_managed_mcp/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GoogleManagedMcpToolset for simplified Google MCP server connections.
+
+Provides a McpToolset subclass that automates ADC-based authentication
+and endpoint URL resolution for Google Managed MCP servers (e.g.,
+BigQuery).
+
+Usage:
+    from google.adk_community.tools.google_managed_mcp import (
+        GoogleManagedMcpToolset,
+    )
+    from google.adk.agents import Agent
+
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+
+    agent = Agent(
+        name="bq_agent",
+        model="gemini-2.5-flash",
+        instruction="Help users query BigQuery.",
+        tools=[toolset],
+    )
+"""
+
+from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+    GoogleManagedMcpToolset,
+)
+
+__all__ = [
+    "GoogleManagedMcpToolset",
+]

--- a/src/google/adk_community/tools/google_managed_mcp/google_managed_mcp_toolset.py
+++ b/src/google/adk_community/tools/google_managed_mcp/google_managed_mcp_toolset.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import TextIO
+from typing import Union
+
+from google.adk.agents.readonly_context import ReadonlyContext
+from google.adk.tools.base_toolset import ToolPredicate
+from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
+from google.adk.tools.mcp_tool.mcp_tool import ProgressCallbackFactory
+from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+from mcp import SamplingCapability
+from mcp.client.session import SamplingFnT
+from mcp.shared.session import ProgressFnT
+
+logger = logging.getLogger("google_adk_community." + __name__)
+
+
+# Maps product names to (endpoint_url, default_scopes).
+# New Google Managed MCP products can be added here as they become available.
+_GOOGLE_MCP_PRODUCTS: Dict[str, tuple[str, list[str]]] = {
+    "bigquery": (
+        "https://bigquery.googleapis.com/mcp",
+        ["https://www.googleapis.com/auth/bigquery"],
+    ),
+}
+
+
+def _create_adc_header_provider(
+    scopes: list[str],
+    project_id: Optional[str] = None,
+) -> Callable[[ReadonlyContext], Dict[str, str]]:
+  """Creates a header_provider that returns fresh ADC Bearer tokens.
+
+  The returned callable refreshes the credential on every call. The
+  ``google-auth`` library internally caches the token and only contacts
+  the metadata server when the token is actually expired, so calling
+  ``credentials.refresh()`` on every request is both safe and efficient.
+
+  Args:
+    scopes: OAuth2 scopes to request when obtaining credentials.
+    project_id: Optional Google Cloud project ID. When provided it is
+      sent as the ``x-goog-user-project`` header for quota attribution.
+
+  Returns:
+    A callable suitable for the ``header_provider`` parameter of
+    :class:`McpToolset`.
+  """
+
+  try:
+    import google.auth
+    import google.auth.transport.requests
+  except ImportError as e:
+    raise ImportError(
+        "google-auth is required for GoogleManagedMcpToolset. "
+        "Install it with: pip install google-adk-community[google-managed-mcp]"
+    ) from e
+
+  credentials, default_project = google.auth.default(scopes=scopes)
+  auth_request = google.auth.transport.requests.Request()
+
+  def _provide_headers(readonly_context: ReadonlyContext) -> Dict[str, str]:
+    """Returns Authorization and optional project headers."""
+    credentials.refresh(auth_request)
+    headers: Dict[str, str] = {
+        "Authorization": f"Bearer {credentials.token}",
+    }
+    resolved_project = project_id or default_project
+    if resolved_project:
+      headers["x-goog-user-project"] = resolved_project
+    return headers
+
+  return _provide_headers
+
+
+class GoogleManagedMcpToolset(McpToolset):
+  """McpToolset subclass for connecting to Google Managed MCP servers.
+
+  This toolset simplifies authentication and connection setup by:
+
+  * Automatically resolving the MCP server URL for a Google product.
+  * Using Application Default Credentials (ADC) with automatic token
+    refresh — no manual token management required.
+
+  The developer only needs to specify the product name (e.g.
+  ``"bigquery"``) and, optionally, a project ID and custom scopes.
+  All other ``McpToolset`` parameters (``tool_filter``,
+  ``tool_name_prefix``, etc.) are forwarded to the parent class.
+
+  Supported products:
+
+  * ``"bigquery"`` — Google BigQuery MCP server.
+
+  Usage::
+
+    from google.adk_community.tools.google_managed_mcp import (
+        GoogleManagedMcpToolset,
+    )
+
+    # Minimal — uses ADC and default BigQuery scopes
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+
+    # With custom project and scopes
+    toolset = GoogleManagedMcpToolset(
+        product="bigquery",
+        project_id="my-project",
+        scopes=["https://www.googleapis.com/auth/bigquery.readonly"],
+        tool_filter=["list_datasets", "execute_sql"],
+    )
+
+    agent = LlmAgent(
+        model="gemini-2.5-flash",
+        name="bq_agent",
+        instruction="Help users query BigQuery.",
+        tools=[toolset],
+    )
+  """
+
+  def __init__(
+      self,
+      *,
+      product: str,
+      project_id: Optional[str] = None,
+      scopes: Optional[list[str]] = None,
+      tool_filter: Optional[Union[ToolPredicate, List[str]]] = None,
+      tool_name_prefix: Optional[str] = None,
+      errlog: TextIO = sys.stderr,
+      require_confirmation: Union[bool, Callable[..., bool]] = False,
+      progress_callback: Optional[
+          Union[ProgressFnT, ProgressCallbackFactory]
+      ] = None,
+      use_mcp_resources: Optional[bool] = False,
+      sampling_callback: Optional[SamplingFnT] = None,
+      sampling_capabilities: Optional[SamplingCapability] = None,
+  ):
+    """Initializes the GoogleManagedMcpToolset.
+
+    Args:
+      product: The Google product to connect to. Must be one of the
+        supported product names (e.g. ``"bigquery"``). Case-insensitive.
+      project_id: Optional Google Cloud project ID for quota attribution.
+        If not provided, the project associated with the Application
+        Default Credentials is used.
+      scopes: Optional list of OAuth2 scopes. If not provided, product-
+        specific default scopes are used.
+      tool_filter: Optional filter to select specific tools. Can be either
+        a list of tool names to include or a ``ToolPredicate`` function
+        for custom filtering logic.
+      tool_name_prefix: A prefix to be added to the name of each tool in
+        this toolset.
+      errlog: TextIO stream for error logging.
+      require_confirmation: Whether tools in this toolset require
+        confirmation. Can be a single boolean or a callable to apply to
+        all tools.
+      progress_callback: Optional callback to receive progress
+        notifications from the MCP server during long-running tool
+        execution.
+      use_mcp_resources: Whether the agent should have access to MCP
+        resources.
+      sampling_callback: Optional callback to handle sampling requests
+        from the MCP server.
+      sampling_capabilities: Optional capabilities for sampling.
+
+    Raises:
+      ValueError: If the product name is not recognized.
+      ImportError: If ``google-auth`` is not installed.
+    """
+    product_key = product.lower()
+    if product_key not in _GOOGLE_MCP_PRODUCTS:
+      supported = ", ".join(sorted(_GOOGLE_MCP_PRODUCTS.keys()))
+      raise ValueError(
+          f"Unknown Google MCP product: '{product}'. "
+          f"Supported products: [{supported}]"
+      )
+
+    endpoint_url, default_scopes = _GOOGLE_MCP_PRODUCTS[product_key]
+    resolved_scopes = scopes or default_scopes
+
+    header_provider = _create_adc_header_provider(
+        scopes=resolved_scopes,
+        project_id=project_id,
+    )
+
+    connection_params = StreamableHTTPConnectionParams(url=endpoint_url)
+
+    super().__init__(
+        connection_params=connection_params,
+        tool_filter=tool_filter,
+        tool_name_prefix=tool_name_prefix,
+        errlog=errlog,
+        require_confirmation=require_confirmation,
+        header_provider=header_provider,
+        progress_callback=progress_callback,
+        use_mcp_resources=use_mcp_resources,
+        sampling_callback=sampling_callback,
+        sampling_capabilities=sampling_capabilities,
+    )

--- a/tests/unittests/tools/google_managed_mcp/__init__.py
+++ b/tests/unittests/tools/google_managed_mcp/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unittests/tools/google_managed_mcp/test_google_managed_mcp_toolset.py
+++ b/tests/unittests/tools/google_managed_mcp/test_google_managed_mcp_toolset.py
@@ -1,0 +1,266 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from google.adk.tools.mcp_tool.mcp_session_manager import (
+    StreamableHTTPConnectionParams,
+)
+import pytest
+
+
+@pytest.fixture
+def mock_google_auth():
+  """Fixture that patches google.auth.default and transport.requests.Request.
+
+  Since google.auth is lazy-imported inside _create_adc_header_provider,
+  we patch the actual google.auth module, not via the toolset's namespace.
+  """
+  mock_credentials = MagicMock()
+  mock_credentials.token = "fake-token-123"
+
+  with patch(
+      "google.auth.default",
+      return_value=(mock_credentials, "fake-project"),
+  ) as mock_default, patch(
+      "google.auth.transport.requests.Request",
+      return_value=MagicMock(),
+  ) as mock_request_cls:
+    yield {
+        "credentials": mock_credentials,
+        "mock_default": mock_default,
+        "mock_request_cls": mock_request_cls,
+    }
+
+
+class TestGoogleManagedMcpToolset:
+  """Test suite for GoogleManagedMcpToolset class."""
+
+  def test_init_valid_product(self, mock_google_auth):
+    """Creating with a supported product name succeeds."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+    assert toolset is not None
+
+  def test_init_unknown_product_raises(self):
+    """Creating with an unsupported product name raises ValueError."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    with pytest.raises(ValueError, match="Unknown Google MCP product"):
+      GoogleManagedMcpToolset(product="unknown_product")
+
+  def test_init_case_insensitive(self, mock_google_auth):
+    """Product name matching is case-insensitive."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(product="BigQuery")
+    assert toolset is not None
+
+    toolset2 = GoogleManagedMcpToolset(product="BIGQUERY")
+    assert toolset2 is not None
+
+  def test_connection_params_url(self, mock_google_auth):
+    """Internal connection params use the correct BigQuery MCP endpoint."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+    assert isinstance(
+        toolset._connection_params, StreamableHTTPConnectionParams
+    )
+    assert (
+        toolset._connection_params.url
+        == "https://bigquery.googleapis.com/mcp"
+    )
+
+  def test_header_provider_is_set(self, mock_google_auth):
+    """A header_provider is automatically configured."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+    assert toolset._header_provider is not None
+    assert callable(toolset._header_provider)
+
+  def test_header_provider_returns_bearer_token(self, mock_google_auth):
+    """The header_provider returns an Authorization Bearer header."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+    mock_context = Mock()
+
+    headers = toolset._header_provider(mock_context)
+
+    assert "Authorization" in headers
+    assert headers["Authorization"] == "Bearer fake-token-123"
+
+  def test_header_provider_refreshes_credentials(self, mock_google_auth):
+    """The header_provider calls credentials.refresh() each time."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+    mock_context = Mock()
+    mock_credentials = mock_google_auth["credentials"]
+
+    # Call header_provider twice
+    toolset._header_provider(mock_context)
+    toolset._header_provider(mock_context)
+
+    assert mock_credentials.refresh.call_count == 2
+
+  def test_custom_scopes(self, mock_google_auth):
+    """Custom scopes are passed to google.auth.default()."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    custom_scopes = [
+        "https://www.googleapis.com/auth/bigquery.readonly"
+    ]
+    GoogleManagedMcpToolset(product="bigquery", scopes=custom_scopes)
+
+    mock_google_auth["mock_default"].assert_called_with(
+        scopes=custom_scopes
+    )
+
+  def test_default_scopes(self, mock_google_auth):
+    """Default product scopes are used when none are specified."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        _GOOGLE_MCP_PRODUCTS,
+        GoogleManagedMcpToolset,
+    )
+
+    GoogleManagedMcpToolset(product="bigquery")
+
+    _, default_scopes = _GOOGLE_MCP_PRODUCTS["bigquery"]
+    mock_google_auth["mock_default"].assert_called_with(
+        scopes=default_scopes
+    )
+
+  def test_custom_project_id(self, mock_google_auth):
+    """Custom project_id is included in the x-goog-user-project header."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(
+        product="bigquery", project_id="my-custom-project"
+    )
+    mock_context = Mock()
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers.get("x-goog-user-project") == "my-custom-project"
+
+  def test_default_project_from_adc(self, mock_google_auth):
+    """When no project_id is given, ADC default project is used."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(product="bigquery")
+    mock_context = Mock()
+
+    headers = toolset._header_provider(mock_context)
+
+    # The mock returns "fake-project" as the default project
+    assert headers.get("x-goog-user-project") == "fake-project"
+
+  def test_tool_filter_forwarded(self, mock_google_auth):
+    """tool_filter parameter is forwarded to the parent McpToolset."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    tool_filter = ["list_datasets", "execute_sql"]
+    toolset = GoogleManagedMcpToolset(
+        product="bigquery", tool_filter=tool_filter
+    )
+    # Verify the parent stored the filter
+    assert toolset._is_tool_selected is not None
+
+  def test_kwargs_forwarded(self, mock_google_auth):
+    """Extra kwargs like use_mcp_resources are forwarded to parent."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(
+        product="bigquery", use_mcp_resources=True
+    )
+    assert toolset._use_mcp_resources is True
+
+  def test_tool_name_prefix_forwarded(self, mock_google_auth):
+    """tool_name_prefix is forwarded to parent McpToolset."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        GoogleManagedMcpToolset,
+    )
+
+    toolset = GoogleManagedMcpToolset(
+        product="bigquery", tool_name_prefix="bq"
+    )
+    assert toolset.tool_name_prefix == "bq"
+
+
+class TestCreateAdcHeaderProvider:
+  """Tests for the _create_adc_header_provider helper function."""
+
+  def test_returns_callable(self, mock_google_auth):
+    """Returns a callable header_provider."""
+    from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+        _create_adc_header_provider,
+    )
+
+    provider = _create_adc_header_provider(
+        scopes=["https://www.googleapis.com/auth/bigquery"]
+    )
+    assert callable(provider)
+
+  def test_no_project_header_when_none(self):
+    """No x-goog-user-project when both project_id and default are None."""
+    mock_credentials = MagicMock()
+    mock_credentials.token = "test-token"
+
+    with patch(
+        "google.auth.default",
+        return_value=(mock_credentials, None),
+    ), patch(
+        "google.auth.transport.requests.Request",
+        return_value=MagicMock(),
+    ):
+      from google.adk_community.tools.google_managed_mcp.google_managed_mcp_toolset import (
+          _create_adc_header_provider,
+      )
+
+      provider = _create_adc_header_provider(
+          scopes=["https://www.googleapis.com/auth/bigquery"],
+          project_id=None,
+      )
+      headers = provider(Mock())
+      assert "x-goog-user-project" not in headers


### PR DESCRIPTION
Introduces GoogleManagedMcpToolset, a McpToolset subclass that automates ADC-based authentication and endpoint URL resolution for Google Managed MCP servers (e.g., BigQuery).

- Auto-refreshes OAuth2 tokens via google.auth on every request
- Maps product names to endpoint URLs (initially supports 'bigquery')
- Supports custom scopes and project ID overrides
- Adds BigQuery MCP sample agent under contributing/samples/
- Adds 16 unit tests covering init, auth, and parameter forwarding
- Adds google-managed-mcp optional dependency in pyproject.toml

Live Test - 

https://github.com/user-attachments/assets/cd2be529-64ac-44ad-b3c3-d016a21ee58b

Closes [google/adk-python #3897](https://github.com/google/adk-python/issues/3897)