### PR TITLE
 fix: avoid duplicate Redis user session separator

### DIFF
--- a/src/google/adk_community/sessions/redis_session_service.py
+++ b/src/google/adk_community/sessions/redis_session_service.py
@@ -55,7 +55,7 @@ class RedisKeys:
 
     @staticmethod
     def user_sessions(app_name: str, user_id: str) -> str:
-        return f"{State.APP_PREFIX}:{app_name}:{user_id}"
+        return f"{State.APP_PREFIX}{app_name}:{user_id}"
 
     @staticmethod
     def app_state(app_name: str) -> str:

--- a/tests/unittests/sessions/test_redis_session_service.py
+++ b/tests/unittests/sessions/test_redis_session_service.py
@@ -21,12 +21,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
 from google.adk.sessions.base_session_service import GetSessionConfig
-from google.adk_community.sessions.redis_session_service import RedisSessionService
+from google.adk_community.sessions.redis_session_service import (
+    RedisKeys,
+    RedisSessionService,
+)
 from google.genai import types
 
 
 class TestRedisSessionService:
     """Test cases for RedisSessionService."""
+
+    def test_user_sessions_key_uses_single_prefix_separator(self):
+        """Test user sessions key does not duplicate the app prefix separator."""
+        assert (
+            RedisKeys.user_sessions("test_app", "test_user")
+            == "app:test_app:test_user"
+        )
 
     @pytest_asyncio.fixture
     async def redis_service(self):


### PR DESCRIPTION
## What

  Fixes Redis user session key generation to avoid adding a duplicate separator after `State.APP_PREFIX`.

  Before:

  `app::test_app:test_user`

  After:

  `app:test_app:test_user`

  ## Why

  `State.APP_PREFIX` already includes the trailing separator, so adding another `:` creates a Redis key with a double colon.

  Closes #34.

  ## Testing

  - Added a regression test for `RedisKeys.user_sessions()`
  - Ran `PYTHONPATH=src uv run pytest tests/unittests/sessions/test_redis_session_service.py`
  - Result: 16 passed

